### PR TITLE
Fix API section sidebar navigation links

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://typedoc.org/schema.json",
+  "docsRoot": "./docs",
   "entryPoints": [
     "packages/fate/src/index.ts",
     "packages/fate/src/server.ts",


### PR DESCRIPTION
## Description

Currently the sidebar's API section is broken, the typedoc links are prefixed with `/docs` and lead to broken pages such as https://fate.technology/docs/api/@nkzw/fate (not sure why the rewrites are not working).

```json
[
  {
    "text": "@nkzw/fate",
    "link": "/api/@nkzw/fate/",
    "collapsed": true,
    "items": [
      {
        "text": "FateClient",
        "link": "/docs/api/@nkzw/fate/classes/FateClient.md" // Starts with /docs
      },
      {
        "text": "FateThenable",
        "link": "/docs/api/@nkzw/fate/interfaces/FateThenable.md"
      },
    ]
    ...
  },
  ...
]
```

The fix is to customize the config for `typedoc.json`:

```json
[
  {
    "text": "@nkzw/fate",
    "link": "/api/@nkzw/fate/",
    "collapsed": true,
    "items": [
      {
        "text": "FateClient",
        "link": "/api/@nkzw/fate/classes/FateClient.md" // No more /docs
      },
      {
        "text": "FateThenable",
        "link": "/api/@nkzw/fate/interfaces/FateThenable.md"
      },
    ]
    ...
  },
  ...
]
```

## Test plan

1. Built the Vitepress site
2. Tested that sidebar links now work