### PR TITLE
Refactor Fate client initialization

### DIFF
--- a/docs/guide/server-integration.md
+++ b/docs/guide/server-integration.md
@@ -250,23 +250,20 @@ import { httpBatchLink } from '@trpc/client';
 import { FateClient } from 'react-fate';
 import { createFateClient } from './fate.ts';
 
+const fate = createFateClient({
+  links: [
+    httpBatchLink({
+      fetch: (input, init) =>
+        fetch(input, {
+          ...init,
+          credentials: 'include',
+        }),
+      url: `${env('SERVER_URL')}/trpc`,
+    }),
+  ],
+});
+
 export function App() {
-  const fate = useMemo(
-    () =>
-      createFateClient({
-        links: [
-          httpBatchLink({
-            fetch: (input, init) =>
-              fetch(input, {
-                ...init,
-                credentials: 'include',
-              }),
-            url: `${env('SERVER_URL')}/trpc`,
-          }),
-        ],
-      }),
-    [],
-  );
   return <FateClient client={fate}>{/* Components go here */}</FateClient>;
 }
 ```


### PR DESCRIPTION
Refactored the Fate client initialization to use a constant instead of useMemo.

Creating the fate client inside of render didn't seem to be required, plus React reserves the right to re-call useMemo so it's not 100% safe anyway.