### PR TITLE
fix: fate logo invisible in light mode

### DIFF
--- a/.vitepress/theme/docs.css
+++ b/.vitepress/theme/docs.css
@@ -134,6 +134,14 @@ html.dark picture.fate-tree > img {
   content: url('/public/fate-tree-dark.svg');
 }
 
+picture.fate-logo > img {
+  content: url('/fate-logo.svg');
+}
+
+html.dark picture.fate-logo > img {
+  content: url('/fate-logo-dark.svg');
+}
+
 .vp-doc[class^='_posts_'] h2,
 .vp-doc[class*=' _posts_'] h2 {
   border-top: 0;

--- a/docs/posts/introducing-fate.md
+++ b/docs/posts/introducing-fate.md
@@ -1,6 +1,6 @@
 <h1 style="font-weight: 500; color: var(--vp-post-headline);">
   Introducing
-  <picture>
+  <picture class="fate-logo">
     <source media="(prefers-color-scheme: dark)" srcset="/fate-logo-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="/fate-logo.svg">
     <img alt="fate" src="/fate-logo.svg" style="display: inline; height: 40px; vertical-align: middle;">


### PR DESCRIPTION
Fate logo invisible in light mode:
<img width="693" height="377" alt="image" src="https://github.com/user-attachments/assets/8903ec38-1c10-44bf-950e-65c0ca27f17f" />
