### PR TITLE
[POC] Add a python fate server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ packages/**/README.md
 !packages/create-fate/README.md
 !packages/create-fate/templates/**/README.md
 !packages/void-fate/README.md
+!packages/py-fate/README.md
 tsconfig.tsbuildinfo
 vite.config.ts.timestamp-*

--- a/packages/py-fate/.gitignore
+++ b/packages/py-fate/.gitignore
@@ -1,0 +1,126 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Ruff cache
+.ruff_cache/

--- a/packages/py-fate/README.md
+++ b/packages/py-fate/README.md
@@ -1,0 +1,233 @@
+# py-fate
+
+Python server implementation of the [fate](https://fate.technology) wire protocol.
+
+`py-fate` lets you serve a fate React client from a Python backend. The core is
+framework-agnostic — bring your own web framework. A first-class **FastAPI**
+integration is included; adapters for any ASGI server are a few lines of glue.
+
+## Status
+
+Version 1 of the wire protocol — `byId` / `list` / `query` / `mutation`
+operations, batched in a single POST, plus a live SSE stream for
+`subscribe` / `subscribeConnection` / `unsubscribe`.
+
+## Install
+
+```bash
+pip install py-fate            # core only
+pip install py-fate[fastapi]   # with FastAPI adapter
+```
+
+## Quick start (FastAPI)
+
+Declare your domain entities (`TypedDict`, Pydantic model, dataclass — anything)
+and a `DataView[Entity]` for each. Annotations on the view are the schema;
+the `Entity` parameter flows back to the caller from typed accessors:
+
+```python
+from typing import TypedDict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from py_fate import (
+    DataView,
+    DictSourceAdapter,
+    MutationDefinition,
+    QueryDefinition,
+    Scalar,
+    computed,
+    create_fate_server,
+    list_field,
+    resolver,
+)
+from py_fate.integrations.fastapi import fate_router
+
+
+class UserEntity(TypedDict):
+    id: str
+    name: str
+
+
+class PostEntity(TypedDict):
+    id: str
+    title: str
+    authorId: str
+
+
+class UserView(DataView[UserEntity]):
+    id: Scalar
+    name: Scalar
+
+
+class PostView(DataView[PostEntity]):
+    id: Scalar
+    title: Scalar
+    author: UserView                       # nested relation by annotation
+
+    @computed(select={"authorId": True})
+    def is_owner(item: PostEntity, deps, ctx) -> bool:
+        return deps.get("authorId") == getattr(ctx, "user_id", None)
+
+    @resolver
+    async def like_count(item: PostEntity, ctx) -> int:
+        return 0  # query your real datastore here
+
+
+adapter = DictSourceAdapter(
+    views={"User": UserView, "Post": PostView},
+    data={
+        "User": [{"id": "u1", "name": "Alice"}],
+        "Post": [{"id": "p1", "title": "Hello", "authorId": "u1"}],
+    },
+    roots={"posts": list_field(PostView)},
+)
+
+
+class CreatePost(BaseModel):
+    title: str
+
+
+async def create_post(*, ctx, input: CreatePost, select):
+    return {"id": "p2", "title": input.title, "authorId": "u1"}
+
+
+async def viewer(*, ctx, input, select):
+    return {"id": "u1", "name": "Alice"}
+
+
+server = create_fate_server(
+    roots={"posts": list_field(PostView)},
+    queries={"viewer": QueryDefinition(resolve=viewer)},
+    mutations={
+        "createPost": MutationDefinition(
+            resolve=create_post, type="Post", input=CreatePost
+        )
+    },
+    sources=adapter,
+)
+
+app = FastAPI()
+app.include_router(fate_router(server), prefix="/fate")
+```
+
+Run it (`uvicorn module:app`) and point your fate React client at
+`http://localhost:8000/fate` with `createFateClient({ url: '/fate' })`.
+
+### Typed `by_id` access
+
+The view's `Entity` parameter flows through `by_id` / `by_id_one` — handy from
+within mutations, resolvers, or anywhere on the server:
+
+```python
+users: list[UserEntity | None] = await UserView.by_id(
+    adapter, ctx, ["u1", "u2"], select=["id", "name"]
+)
+alice: UserEntity | None = await UserView.by_id_one(
+    adapter, ctx, "u1", select=["id", "name"]
+)
+```
+
+### Conventions
+
+- `type_name` is inferred from the class name with a trailing ``View`` stripped
+  (`PostView` → `"Post"`); override with
+  `class PostView(DataView[PostEntity], type_name="Article")`.
+- Plain Python annotations (`id: int`, `name: str`) are treated as scalars —
+  `Scalar` is just the most explicit spelling.
+- `list[OtherView]` annotations are recognized as list relations.
+- The `Entity` generic parameter is optional. Omitting it (`class UserView(DataView)`)
+  defaults to `Any`, which keeps untyped resolver bodies working.
+
+## Using something other than FastAPI
+
+The core never imports FastAPI. `FateServer.handle_request` /
+`handle_live_get` / `handle_live_post` operate on a small
+`FateHTTPRequest` / `FateHTTPResponse` value object pair you build from your
+framework's request type.
+
+### Generic ASGI (Starlette, Litestar, Quart, …)
+
+```python
+from py_fate.integrations.asgi import fate_asgi_app
+asgi = fate_asgi_app(server, prefix="/fate")
+# Mount under any ASGI host or run directly with uvicorn:
+# uvicorn module:asgi --port 8000
+```
+
+### Starlette mount
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from py_fate.integrations.asgi import fate_asgi_app
+
+app = Starlette(routes=[Mount("/fate", app=fate_asgi_app(server))])
+```
+
+### Hand-rolled adapter (any framework)
+
+```python
+from py_fate import FateHTTPRequest
+
+async def my_endpoint(framework_request):
+    async def read_body():
+        return await framework_request.body()
+    fate_req = FateHTTPRequest(
+        method=framework_request.method,
+        url=str(framework_request.url),
+        headers=dict(framework_request.headers),
+        read_body=read_body,
+    )
+    response = await server.handle_request(fate_req)
+    return framework.Response(
+        content=response.body,
+        status_code=response.status,
+        headers=response.headers,
+    )
+```
+
+## Live (SSE)
+
+```python
+from py_fate import create_live_event_bus
+
+bus = create_live_event_bus()
+server = create_fate_server(..., live=bus)
+
+# Push updates whenever an entity changes:
+await bus.emit("Post", post_id, changed=["likes"], event_id=f"post:{post_id}:{now}")
+await bus.delete("Post", post_id)
+```
+
+The default in-memory bus is single-process; production deployments can
+implement a custom `LiveEventBus` backed by Redis / NATS / Kafka without
+touching the rest of the server.
+
+## Authentication
+
+Pass a `context` factory to `create_fate_server`:
+
+```python
+from py_fate import FateRequestError
+
+async def make_context(*, request, adapter_context):
+    auth = request.headers.get("authorization")
+    if not auth:
+        raise FateRequestError("UNAUTHORIZED", "Missing token.")
+    user = await load_user(auth)
+    return {"user": user}
+
+server = create_fate_server(..., context=make_context)
+```
+
+The returned value is passed as `ctx` to every resolver.
+
+## Development
+
+```bash
+uv sync
+uv run pytest
+uv run ruff check
+uv run ty check
+```

--- a/packages/py-fate/pyproject.toml
+++ b/packages/py-fate/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "py-fate"
+version = "0.1.0"
+description = "Python server implementation of the fate wire protocol."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "fate contributors" }]
+dependencies = [
+    "pydantic>=2.5",
+    "typing-extensions>=4.12",
+]
+
+[project.optional-dependencies]
+fastapi = ["fastapi>=0.110"]
+asgi = ["starlette>=0.36"]
+
+[project.urls]
+Homepage = "https://fate.technology"
+Repository = "https://github.com/nkzw-tech/fate"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/py_fate"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "httpx>=0.27",
+    "fastapi>=0.110",
+    "starlette>=0.36",
+    "ruff>=0.6",
+    "ty>=0.0.1a14",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ty.src]
+include = ["src", "tests"]
+
+[tool.ty.environment]
+python-version = "3.11"

--- a/packages/py-fate/pyrightconfig.json
+++ b/packages/py-fate/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "pythonVersion": "3.11",
+  "pythonPlatform": "Darwin",
+  "venvPath": ".",
+  "venv": ".venv",
+  "include": ["src", "tests"],
+  "exclude": [".venv", "**/__pycache__"],
+  "extraPaths": ["src"]
+}

--- a/packages/py-fate/src/py_fate/__init__.py
+++ b/packages/py-fate/src/py_fate/__init__.py
@@ -1,0 +1,104 @@
+"""py-fate — Python server for the fate wire protocol."""
+
+from .connection import resolve_connection
+from .data_view import (
+    ComputedField,
+    DataView,
+    EntityT,
+    ListField,
+    ResolverField,
+    Scalar,
+    as_view,
+    computed,
+    list_field,
+    resolver,
+)
+from .executor import (
+    ListDefinition,
+    MutationDefinition,
+    QueryDefinition,
+    ServerRegistry,
+)
+from .http import (
+    FateHTTPRequest,
+    FateHTTPResponse,
+    FateSSEResponse,
+    json_response,
+)
+from .live import (
+    InMemoryLiveEventBus,
+    LiveConnectionSourceEvent,
+    LiveEventBus,
+    LiveSourceEvent,
+    create_live_event_bus,
+)
+from .protocol import (
+    PROTOCOL_VERSION,
+    FateOperation,
+    FateOperationErr,
+    FateOperationOk,
+    FateOperationResult,
+    FateProtocolError,
+    FateProtocolErrorCode,
+    FateProtocolRequest,
+    FateProtocolResponse,
+    FateRequestError,
+    Pagination,
+    status_from_error_code,
+)
+from .server import FateServer, create_fate_server, new_connection_id
+from .source import (
+    ByIdRequest,
+    ConnectionRequest,
+    DictSourceAdapter,
+    SourceAdapter,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "ByIdRequest",
+    "ComputedField",
+    "ConnectionRequest",
+    "DataView",
+    "DictSourceAdapter",
+    "EntityT",
+    "FateHTTPRequest",
+    "FateHTTPResponse",
+    "FateOperation",
+    "FateOperationErr",
+    "FateOperationOk",
+    "FateOperationResult",
+    "FateProtocolError",
+    "FateProtocolErrorCode",
+    "FateProtocolRequest",
+    "FateProtocolResponse",
+    "FateRequestError",
+    "FateSSEResponse",
+    "FateServer",
+    "InMemoryLiveEventBus",
+    "ListDefinition",
+    "ListField",
+    "LiveConnectionSourceEvent",
+    "LiveEventBus",
+    "LiveSourceEvent",
+    "MutationDefinition",
+    "PROTOCOL_VERSION",
+    "Pagination",
+    "QueryDefinition",
+    "ResolverField",
+    "Scalar",
+    "ServerRegistry",
+    "SourceAdapter",
+    "__version__",
+    "as_view",
+    "computed",
+    "create_fate_server",
+    "create_live_event_bus",
+    "json_response",
+    "list_field",
+    "new_connection_id",
+    "resolve_connection",
+    "resolver",
+    "status_from_error_code",
+]

--- a/packages/py-fate/src/py_fate/connection.py
+++ b/packages/py-fate/src/py_fate/connection.py
@@ -1,0 +1,182 @@
+"""Cursor pagination helpers — direct port of `packages/fate/src/server/connection.ts`."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .protocol import ConnectionItem, FateConnectionResult, FateRequestError, Pagination
+
+Direction = Literal["forward", "backward"]
+
+CursorValue = str | int
+PAGINATION_ARG_KEYS = {"after", "before", "first", "last"}
+DEFAULT_PAGE_SIZE = 20
+
+
+@dataclass(slots=True)
+class PaginationArgs:
+    after: str | None = None
+    before: str | None = None
+    first: int | None = None
+    last: int | None = None
+
+
+@dataclass(slots=True)
+class QueryParams:
+    ctx: Any
+    cursor: str | None
+    direction: Direction
+    input: dict[str, Any]
+    skip: int | None
+    take: int
+
+
+QueryFn = Callable[[QueryParams], Awaitable[Sequence[Any]]]
+MapFn = Callable[[Any, dict[str, Any], list[Any]], Awaitable[list[Any]]]
+GetCursorFn = Callable[[Any], CursorValue]
+
+
+def _parse_pagination_args(raw: dict[str, Any] | None) -> PaginationArgs:
+    if not raw:
+        return PaginationArgs()
+
+    args = PaginationArgs()
+    if "after" in raw:
+        v = raw["after"]
+        if v is not None and not isinstance(v, str):
+            raise FateRequestError("VALIDATION_ERROR", "'after' must be a string.")
+        args.after = v
+    if "before" in raw:
+        v = raw["before"]
+        if v is not None and not isinstance(v, str):
+            raise FateRequestError("VALIDATION_ERROR", "'before' must be a string.")
+        args.before = v
+    if "first" in raw:
+        v = raw["first"]
+        if v is not None and (not isinstance(v, int) or isinstance(v, bool) or v <= 0):
+            raise FateRequestError("VALIDATION_ERROR", "'first' must be a positive integer.")
+        args.first = v
+    if "last" in raw:
+        v = raw["last"]
+        if v is not None and (not isinstance(v, int) or isinstance(v, bool) or v <= 0):
+            raise FateRequestError("VALIDATION_ERROR", "'last' must be a positive integer.")
+        args.last = v
+
+    if args.after is not None and args.before is not None:
+        raise FateRequestError(
+            "VALIDATION_ERROR",
+            "Connection args can't include both 'after' and 'before'.",
+        )
+    if args.first is not None and args.last is not None:
+        raise FateRequestError(
+            "VALIDATION_ERROR",
+            "Connection args can't include both 'first' and 'last'.",
+        )
+    return args
+
+
+def extract_pagination_args(args: dict[str, Any] | None) -> dict[str, Any]:
+    if not args:
+        return {}
+    return {key: args[key] for key in PAGINATION_ARG_KEYS if key in args}
+
+
+def _default_get_cursor(node: Any) -> CursorValue:
+    if isinstance(node, dict):
+        if "id" not in node:
+            raise FateRequestError(
+                "INTERNAL_ERROR",
+                "Default cursor requires nodes to have an 'id' field.",
+            )
+        cursor = node["id"]
+    else:
+        cursor = getattr(node, "id", None)
+        if cursor is None:
+            raise FateRequestError(
+                "INTERNAL_ERROR",
+                "Default cursor requires nodes to have an 'id' attribute.",
+            )
+    return cursor
+
+
+async def resolve_connection(
+    *,
+    ctx: Any,
+    input: dict[str, Any],
+    query: QueryFn,
+    default_size: int = DEFAULT_PAGE_SIZE,
+    get_cursor: GetCursorFn = _default_get_cursor,
+    map_items: MapFn | None = None,
+) -> FateConnectionResult:
+    """Resolve a paginated connection.
+
+    Mirrors `resolveConnection` in `packages/fate/src/server/connection.ts`.
+
+    `query` is called with `pageSize + 1` items requested so we can detect a "has more"
+    boundary. `skip=1` when a cursor is provided so the cursor row itself is skipped.
+    """
+
+    args = _parse_pagination_args(extract_pagination_args(input.get("args")))
+    is_backward = args.before is not None or args.last is not None
+    cursor = args.before if is_backward else args.after
+    direction: Direction = "backward" if is_backward else "forward"
+    page_size = args.first if args.first is not None else args.last
+    if page_size is None:
+        page_size = default_size
+
+    raw_items = list(
+        await query(
+            QueryParams(
+                ctx=ctx,
+                cursor=cursor,
+                direction=direction,
+                input=input,
+                skip=1 if cursor else None,
+                take=page_size + 1,
+            )
+        )
+    )
+
+    has_more = len(raw_items) > page_size
+    if is_backward:
+        limited = raw_items[-page_size:] if raw_items else raw_items
+    else:
+        limited = raw_items[:page_size]
+
+    nodes = await map_items(ctx, input, limited) if map_items else list(limited)
+
+    items: list[ConnectionItem] = [
+        ConnectionItem(cursor=str(get_cursor(node)), node=node) for node in nodes
+    ]
+    first_item = items[0] if items else None
+    last_item = items[-1] if items else None
+
+    has_next = bool(cursor) if is_backward else has_more
+    has_previous = has_more if is_backward else bool(cursor)
+
+    return FateConnectionResult(
+        items=items,
+        pagination=Pagination(
+            hasNext=has_next,
+            hasPrevious=has_previous,
+            nextCursor=last_item.cursor if last_item else None,
+            previousCursor=(
+                first_item.cursor if first_item and (has_previous or is_backward) else None
+            ),
+        ),
+    )
+
+
+__all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "Direction",
+    "GetCursorFn",
+    "MapFn",
+    "PaginationArgs",
+    "QueryFn",
+    "QueryParams",
+    "extract_pagination_args",
+    "resolve_connection",
+]

--- a/packages/py-fate/src/py_fate/data_view.py
+++ b/packages/py-fate/src/py_fate/data_view.py
@@ -1,0 +1,492 @@
+"""Declarative data view definitions.
+
+Views are declared as `DataView` subclasses. The class generic parameter is the
+domain entity type — typed `by_id` access flows it back to the caller:
+
+    from typing import TypedDict
+
+    class UserEntity(TypedDict):
+        id: str
+        name: str
+
+    class UserView(DataView[UserEntity]):
+        id: Scalar
+        name: Scalar
+
+    user: UserEntity | None = (await UserView.by_id(adapter, ctx, "u1"))[0]
+
+Relations, list relations, and computed/resolver methods all read naturally:
+
+    class PostView(DataView[PostEntity]):
+        id: Scalar
+        title: Scalar
+        author: UserView                    # nested relation by annotation
+        comments: list[CommentView]         # list relation by annotation
+
+        @computed(select={"authorId": True})
+        def is_owner(item: PostEntity, deps, ctx) -> bool:
+            return deps["authorId"] == ctx.user.id
+
+        @resolver
+        async def like_count(item: PostEntity, ctx) -> int:
+            return await count_likes(ctx, item["id"])
+
+`type_name` defaults to the class name with a trailing ``View`` stripped
+(``PostView`` -> ``"Post"``). Override with ``class PostView(DataView[E], type_name="Article")``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
+
+from typing_extensions import TypeVar as TypeVarExt
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .source import SourceAdapter
+
+Item = TypeVar("Item")
+Result = TypeVar("Result")
+Context = TypeVar("Context")
+
+# Entity type parameter for `DataView`. Unparameterized views default to `Any`,
+# so existing untyped code keeps working; users who type their entities (with
+# `TypedDict`, a Pydantic model, or a dataclass) get those types back from
+# `view.by_id(...)` and friends.
+EntityT = TypeVarExt("EntityT", default=Any)
+
+
+class Scalar:
+    """Annotation marker for a plain scalar field on a `DataView`.
+
+    Any non-view annotation (``int``, ``str``, ``bool``, …) is also treated as
+    a scalar; ``Scalar`` is just the most explicit spelling.
+    """
+
+    __slots__ = ()
+
+
+@dataclass(slots=True)
+class ResolverField(Generic[Item, Result, Context]):
+    """Field whose value is produced by an async resolver."""
+
+    resolve: Callable[..., Awaitable[Result] | Result]
+    authorize: Callable[..., bool] | None = None
+    select: dict[str, Any] | Callable[..., dict[str, Any]] | None = None
+    kind: str = "resolver"
+
+
+@dataclass(slots=True)
+class ComputedField(Generic[Item, Result, Context]):
+    """Field derived from other selected fields on the same entity."""
+
+    resolve: Callable[..., Result]
+    select: dict[str, Any] = field(default_factory=dict)
+    authorize: Callable[..., bool] | None = None
+    kind: str = "computed"
+
+
+@dataclass(slots=True)
+class ListField:
+    """A list / connection relation.
+
+    `view` may be `None` only momentarily when constructed via ``list_field()``
+    without an explicit view inside a class-based DataView; it is then filled in
+    from the surrounding ``list[SomeView]`` annotation before the view is used.
+    """
+
+    view: DataView[Any] | None
+    order_by: list[tuple[str, str]] | None = None
+    procedure: str | None = None
+    default_size: int | None = None
+    kind: str = "list"
+
+
+FieldSpec = Union[
+    bool,
+    "DataView[Any]",
+    ListField,
+    ResolverField[Any, Any, Any],
+    ComputedField[Any, Any, Any],
+]
+
+
+_MISSING: Any = object()
+
+
+class DataView(Generic[EntityT]):
+    """A typed view over a domain entity.
+
+    Subclass to declare a view; the generic parameter is the entity type:
+
+        class UserView(DataView[UserEntity]):
+            id: Scalar
+            name: Scalar
+
+    `DataView` cannot be instantiated directly — declare a subclass.
+    """
+
+    type_name: str
+    fields: dict[str, FieldSpec]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise TypeError(
+            "DataView is not directly constructible. "
+            "Subclass it instead: `class UserView(DataView[UserEntity]): ...`"
+        )
+
+    def __init_subclass__(cls, *, type_name: str | None = None, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.type_name = type_name or _infer_type_name(cls.__name__)
+        # Capture the defining frame so string-form annotations (e.g. when the
+        # caller uses ``from __future__ import annotations``) can be resolved
+        # against the surrounding function/class scope.
+        try:
+            frame = sys._getframe(1)
+            globalns: dict[str, Any] | None = frame.f_globals
+            localns: dict[str, Any] | None = dict(frame.f_locals)
+        except (ValueError, AttributeError):  # pragma: no cover
+            globalns = None
+            localns = None
+        cls.fields = _collect_fields(cls, globalns=globalns, localns=localns)
+
+    # ---------- typed accessors ----------
+
+    @classmethod
+    async def by_id(
+        cls,
+        adapter: SourceAdapter,
+        ctx: Any,
+        ids: Sequence[str | int],
+        select: Sequence[str] | None = None,
+    ) -> list[EntityT | None]:
+        """Fetch a batch of entities by id through ``adapter``."""
+
+        from .source import ByIdRequest
+
+        request: ByIdRequest[EntityT] = ByIdRequest(
+            ctx=ctx,
+            type=cls.type_name,
+            ids=list(ids),
+            select=list(select or []),
+        )
+        return await adapter.resolve_by_ids(request)
+
+    @classmethod
+    async def by_id_one(
+        cls,
+        adapter: SourceAdapter,
+        ctx: Any,
+        id: str | int,
+        select: Sequence[str] | None = None,
+    ) -> EntityT | None:
+        """Fetch a single entity by id (convenience over `by_id`)."""
+
+        results = await cls.by_id(adapter, ctx, [id], select)
+        return results[0] if results else None
+
+    @classmethod
+    def has(cls, name: str) -> bool:
+        return name in cls.fields
+
+    @classmethod
+    def get(cls, name: str) -> FieldSpec | None:
+        return cls.fields.get(name)
+
+
+# ---------- decorators for class-based views ----------
+
+
+@dataclass(slots=True)
+class _ComputedMarker:
+    """Returned by ``@computed(...)``; converted to a ComputedField at collection."""
+
+    resolve: Callable[..., Any]
+    select: dict[str, Any]
+    authorize: Callable[..., bool] | None
+
+
+@dataclass(slots=True)
+class _ResolverMarker:
+    """Returned by ``@resolver`` / ``@resolver(...)``; converted at collection."""
+
+    resolve: Callable[..., Any]
+    select: dict[str, Any] | Callable[..., dict[str, Any]] | None
+    authorize: Callable[..., bool] | None
+
+
+def computed(
+    *,
+    select: dict[str, Any] | None = None,
+    authorize: Callable[..., bool] | None = None,
+) -> Callable[[Callable[..., Any]], _ComputedMarker]:
+    """Decorate a method to declare it as a `ComputedField`.
+
+    `select` lists the source fields whose values are passed in `deps`.
+    """
+
+    def deco(fn: Callable[..., Any]) -> _ComputedMarker:
+        return _ComputedMarker(resolve=fn, select=select or {}, authorize=authorize)
+
+    return deco
+
+
+def resolver(
+    fn: Callable[..., Any] | None = None,
+    *,
+    select: dict[str, Any] | Callable[..., dict[str, Any]] | None = None,
+    authorize: Callable[..., bool] | None = None,
+) -> Any:
+    """Decorate a method to declare it as a `ResolverField`.
+
+    Usable bare (``@resolver``) or with arguments (``@resolver(select=...)``).
+    """
+
+    def deco(actual: Callable[..., Any]) -> _ResolverMarker:
+        return _ResolverMarker(resolve=actual, select=select, authorize=authorize)
+
+    if fn is not None and callable(fn):
+        return deco(fn)
+    return deco
+
+
+# ---------- public helpers ----------
+
+
+def list_field(
+    view: DataView[Any] | type[DataView[Any]] | None = None,
+    *,
+    order_by: list[tuple[str, str]] | None = None,
+    procedure: str | None = None,
+    default_size: int | None = None,
+) -> Any:
+    """Build a `ListField`.
+
+    `view` may be a `DataView` subclass (class form) or a materialized
+    `DataView` instance. When used as a default value alongside a
+    ``list[SomeView]`` annotation, the view may be omitted and will be inferred
+    from the annotation.
+
+    Returns `Any` (rather than `ListField`) so the call site can satisfy a
+    ``list[SomeView]`` annotation in class-based `DataView` definitions —
+    this mirrors `dataclasses.field()`.
+    """
+
+    return ListField(
+        view=as_view(view) if view is not None else None,
+        order_by=order_by,
+        procedure=procedure,
+        default_size=default_size,
+    )
+
+
+def as_view(spec: Any) -> DataView[Any]:
+    """Coerce a `DataView` subclass to a canonical `DataView` instance.
+
+    Idempotent. Raises `TypeError` if `spec` is neither a `DataView` instance
+    nor a `DataView` subclass.
+    """
+
+    if isinstance(spec, DataView):
+        return spec
+    if isinstance(spec, type) and issubclass(spec, DataView):
+        return _materialize_class_view(spec)
+    raise TypeError(
+        f"Expected DataView subclass, got {type(spec).__name__}"
+    )
+
+
+# ---------- internal collection logic ----------
+
+
+def _infer_type_name(class_name: str) -> str:
+    if class_name.endswith("View") and len(class_name) > len("View"):
+        return class_name[: -len("View")]
+    return class_name
+
+
+def _materialize_class_view(cls: type[DataView[Any]]) -> DataView[Any]:
+    """Build (once, cached on the class) a `DataView` instance from a subclass.
+
+    Internal: bypasses `DataView.__init__` (which raises) via `__new__`.
+    """
+
+    cached = cls.__dict__.get("__fate_view_instance__")
+    if cached is not None:
+        return cast("DataView[Any]", cached)
+    inst = cast("DataView[Any]", DataView.__new__(cls))
+    inst.type_name = cls.type_name
+    inst.fields = cls.fields
+    setattr(cls, "__fate_view_instance__", inst)  # noqa: B010
+    return inst
+
+
+def _collect_fields(
+    cls: type,
+    *,
+    globalns: dict[str, Any] | None = None,
+    localns: dict[str, Any] | None = None,
+) -> dict[str, FieldSpec]:
+    """Build the `fields` dict for a class-based DataView subclass.
+
+    Inherits parent `DataView`-subclass fields; the child's own annotations and
+    decorated methods override them.
+    """
+
+    out: dict[str, FieldSpec] = {}
+
+    # Inherit from any parent DataView subclasses (parents first; child wins).
+    for base in reversed(cls.__mro__[1:]):
+        if base is DataView or base is object or base is Generic:
+            continue
+        parent_fields = base.__dict__.get("fields")
+        if isinstance(parent_fields, dict):
+            out.update(parent_fields)
+
+    # Resolution namespace for string-form annotations.
+    resolve_globals: dict[str, Any] = dict(globals())
+    user_module = sys.modules.get(cls.__module__)
+    if user_module is not None:
+        resolve_globals.update(vars(user_module))
+    if globalns:
+        resolve_globals.update(globalns)
+    resolve_locals = dict(localns or {})
+
+    own_annotations = getattr(cls, "__annotations__", {}) or {}
+    for name, anno in own_annotations.items():
+        if name.startswith("_") or name in {"type_name", "fields"}:
+            continue
+        resolved_anno = _resolve_annotation(anno, resolve_globals, resolve_locals)
+        if get_origin(resolved_anno) is ClassVar:
+            continue
+        default = cls.__dict__.get(name, _MISSING)
+        spec = _build_spec(resolved_anno, default)
+        if spec is _MISSING:
+            continue
+        out[name] = _normalize_spec(spec)
+
+    # Methods decorated with @computed / @resolver have no annotation.
+    for name, member in cls.__dict__.items():
+        if name.startswith("_"):
+            continue
+        if isinstance(member, _ComputedMarker):
+            out[name] = ComputedField(
+                resolve=member.resolve,
+                select=member.select,
+                authorize=member.authorize,
+            )
+        elif isinstance(member, _ResolverMarker):
+            out[name] = ResolverField(
+                resolve=member.resolve,
+                select=member.select,
+                authorize=member.authorize,
+            )
+
+    return out
+
+
+def _resolve_annotation(
+    anno: Any, globalns: dict[str, Any], localns: dict[str, Any]
+) -> Any:
+    if isinstance(anno, str):
+        try:
+            return eval(anno, globalns, localns)
+        except Exception:
+            return anno
+    return anno
+
+
+def _build_spec(anno: Any, default: Any) -> FieldSpec | Any:
+    # An explicit default wins, with one exception: a `list_field()` whose view
+    # is unset falls back to the surrounding `list[SomeView]` annotation.
+    if isinstance(default, ListField):
+        if default.view is None:
+            inferred = _view_from_list_annotation(anno)
+            if inferred is not None:
+                default.view = inferred
+        return default
+    if isinstance(default, (ResolverField, ComputedField)):
+        return default
+    if isinstance(default, _ComputedMarker):
+        return ComputedField(
+            resolve=default.resolve,
+            select=default.select,
+            authorize=default.authorize,
+        )
+    if isinstance(default, _ResolverMarker):
+        return ResolverField(
+            resolve=default.resolve,
+            select=default.select,
+            authorize=default.authorize,
+        )
+    if isinstance(default, DataView):
+        return default
+    if isinstance(default, type) and issubclass(default, DataView):
+        return default
+
+    # No default — derive from annotation.
+    if anno is Scalar:
+        return True
+    if isinstance(anno, DataView):
+        return anno
+    if isinstance(anno, type) and issubclass(anno, DataView):
+        return anno
+    inferred = _view_from_list_annotation(anno)
+    if inferred is not None:
+        return ListField(view=inferred)
+
+    # Anything else (str, int, bool, etc.) is a plain scalar.
+    return True
+
+
+def _view_from_list_annotation(anno: Any) -> DataView[Any] | None:
+    if get_origin(anno) is not list:
+        return None
+    args = get_args(anno)
+    if not args:
+        return None
+    inner = args[0]
+    if isinstance(inner, DataView):
+        return inner
+    if isinstance(inner, type) and issubclass(inner, DataView):
+        return _materialize_class_view(inner)
+    return None
+
+
+def _normalize_spec(spec: FieldSpec) -> FieldSpec:
+    """Convert any class-form view inside `spec` into a `DataView` instance."""
+
+    if isinstance(spec, type) and issubclass(spec, DataView):
+        return _materialize_class_view(spec)
+    if isinstance(spec, ListField):
+        if isinstance(spec.view, type) and issubclass(spec.view, DataView):
+            spec.view = _materialize_class_view(spec.view)
+        return spec
+    return spec
+
+
+__all__ = [
+    "ComputedField",
+    "DataView",
+    "EntityT",
+    "FieldSpec",
+    "ListField",
+    "ResolverField",
+    "Scalar",
+    "as_view",
+    "computed",
+    "list_field",
+    "resolver",
+]

--- a/packages/py-fate/src/py_fate/executor.py
+++ b/packages/py-fate/src/py_fate/executor.py
@@ -1,0 +1,201 @@
+"""Per-operation dispatch.
+
+Mirrors the executor section of `createFateServer` in
+`packages/fate/src/server/http.ts`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from .data_view import DataView, ListField
+from .input import InputSchema, parse_input
+from .protocol import (
+    FateOperation,
+    FateOperationErr,
+    FateOperationOk,
+    FateOperationResult,
+    FateRequestError,
+    to_protocol_error,
+)
+from .source import ByIdRequest, ConnectionRequest, SourceAdapter
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+
+Resolver = Callable[..., Awaitable[Any] | Any]
+
+
+@dataclass(slots=True)
+class QueryDefinition:
+    resolve: Resolver
+    type: str | None = None
+
+
+@dataclass(slots=True)
+class ListDefinition:
+    resolve: Resolver
+    type: str | None = None
+    default_size: int | None = None
+
+
+@dataclass(slots=True)
+class MutationDefinition:
+    resolve: Resolver
+    type: str
+    input: InputSchema = None
+
+
+@dataclass(slots=True)
+class ServerRegistry:
+    """All the user-registered surfaces the executor dispatches against."""
+
+    queries: dict[str, QueryDefinition] = field(default_factory=dict)
+    lists: dict[str, ListDefinition] = field(default_factory=dict)
+    mutations: dict[str, MutationDefinition] = field(default_factory=dict)
+    roots: dict[str, DataView[Any] | ListField] = field(default_factory=dict)
+    sources: SourceAdapter | None = None
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def execute_operation(
+    operation: FateOperation,
+    ctx: Any,
+    registry: ServerRegistry,
+) -> FateOperationResult:
+    """Execute a single operation and return the matching result envelope."""
+
+    try:
+        if operation.kind == "byId":
+            return await _execute_by_id(operation, ctx, registry)
+        if operation.kind == "list":
+            return await _execute_list(operation, ctx, registry)
+        if operation.kind == "query":
+            return await _execute_query(operation, ctx, registry)
+        if operation.kind == "mutation":
+            return await _execute_mutation(operation, ctx, registry)
+        raise FateRequestError("BAD_REQUEST", f"Unknown operation kind '{operation.kind}'.")
+    except BaseException as error:  # noqa: BLE001
+        if isinstance(error, (KeyboardInterrupt, SystemExit)):
+            raise
+        return FateOperationErr(id=operation.id, error=to_protocol_error(error))
+
+
+async def _execute_by_id(
+    operation: FateOperation, ctx: Any, registry: ServerRegistry
+) -> FateOperationResult:
+    if not operation.type or operation.ids is None:
+        raise FateRequestError("BAD_REQUEST", "byId operations require type and ids.")
+    if registry.sources is None:
+        raise FateRequestError(
+            "NOT_FOUND", f"No source registered for '{operation.type}'."
+        )
+    view = registry.sources.view_for(operation.type)
+    if view is None:
+        raise FateRequestError(
+            "NOT_FOUND", f"No source registered for '{operation.type}'."
+        )
+    data = await registry.sources.resolve_by_ids(
+        ByIdRequest(
+            ctx=ctx, type=operation.type, ids=list(operation.ids), select=list(operation.select)
+        )
+    )
+    return FateOperationOk(id=operation.id, data=data)
+
+
+async def _execute_list(
+    operation: FateOperation, ctx: Any, registry: ServerRegistry
+) -> FateOperationResult:
+    if not operation.name:
+        raise FateRequestError("BAD_REQUEST", "list operations require a name.")
+
+    custom = registry.lists.get(operation.name)
+    if custom is not None:
+        data = await _maybe_await(
+            custom.resolve(
+                ctx=ctx,
+                input={"args": operation.args},
+                select=list(operation.select),
+            )
+        )
+        return FateOperationOk(id=operation.id, data=data)
+
+    root = registry.roots.get(operation.name)
+    if root is None:
+        raise FateRequestError("NOT_FOUND", f"No list registered for '{operation.name}'.")
+    if not isinstance(root, ListField):
+        raise FateRequestError(
+            "BAD_REQUEST", f"Root '{operation.name}' is not a list."
+        )
+    if registry.sources is None:
+        raise FateRequestError(
+            "NOT_FOUND", f"No source registered for '{operation.name}'."
+        )
+
+    procedure = root.procedure or operation.name
+    data = await registry.sources.resolve_connection(
+        ConnectionRequest(
+            ctx=ctx, procedure=procedure, args=operation.args, select=list(operation.select)
+        )
+    )
+    return FateOperationOk(id=operation.id, data=data)
+
+
+async def _execute_query(
+    operation: FateOperation, ctx: Any, registry: ServerRegistry
+) -> FateOperationResult:
+    if not operation.name:
+        raise FateRequestError("BAD_REQUEST", "query operations require a name.")
+
+    custom = registry.queries.get(operation.name)
+    if custom is None:
+        raise FateRequestError("NOT_FOUND", f"No query registered for '{operation.name}'.")
+
+    data = await _maybe_await(
+        custom.resolve(
+            ctx=ctx,
+            input={"args": operation.args},
+            select=list(operation.select),
+        )
+    )
+    return FateOperationOk(id=operation.id, data=data)
+
+
+async def _execute_mutation(
+    operation: FateOperation, ctx: Any, registry: ServerRegistry
+) -> FateOperationResult:
+    if not operation.name:
+        raise FateRequestError("BAD_REQUEST", "mutation operations require a name.")
+
+    mutation = registry.mutations.get(operation.name)
+    if mutation is None:
+        raise FateRequestError("NOT_FOUND", f"No mutation registered for '{operation.name}'.")
+
+    parsed = await parse_input(mutation.input, operation.input)
+    data = await _maybe_await(
+        mutation.resolve(
+            ctx=ctx,
+            input=parsed,
+            select=list(operation.select),
+        )
+    )
+    return FateOperationOk(id=operation.id, data=data)
+
+
+__all__ = [
+    "ListDefinition",
+    "MutationDefinition",
+    "QueryDefinition",
+    "Resolver",
+    "ServerRegistry",
+    "execute_operation",
+]

--- a/packages/py-fate/src/py_fate/http.py
+++ b/packages/py-fate/src/py_fate/http.py
@@ -1,0 +1,70 @@
+"""Framework-agnostic request/response value objects.
+
+`FateServer` only depends on these — no Starlette, FastAPI, or AIOHTTP types are
+imported by the core. Web framework adapters convert their native request type
+into a `FateHTTPRequest` and translate `FateHTTPResponse` / `FateSSEResponse`
+back into their native response type.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class FateHTTPRequest:
+    """Minimal HTTP request the protocol layer needs."""
+
+    method: str
+    url: str
+    headers: Mapping[str, str]
+    read_body: Callable[[], Awaitable[bytes]]
+    _cached_body: bytes | None = None
+
+    async def body(self) -> bytes:
+        if self._cached_body is None:
+            self._cached_body = await self.read_body()
+        return self._cached_body
+
+    async def json(self) -> Any:
+        raw = await self.body()
+        if not raw:
+            return None
+        return json.loads(raw)
+
+
+@dataclass(slots=True)
+class FateHTTPResponse:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass(slots=True)
+class FateSSEResponse:
+    """SSE response: caller iterates `frames` and writes them as they arrive."""
+
+    status: int
+    headers: dict[str, str]
+    frames: AsyncIterator[bytes]
+    on_close: Callable[[], Awaitable[None]] | None = None
+
+
+JSON_HEADERS: dict[str, str] = {"content-type": "application/json; charset=utf-8"}
+
+
+def json_response(payload: Any, *, status: int = 200) -> FateHTTPResponse:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return FateHTTPResponse(status=status, headers=dict(JSON_HEADERS), body=body)
+
+
+__all__ = [
+    "FateHTTPRequest",
+    "FateHTTPResponse",
+    "FateSSEResponse",
+    "JSON_HEADERS",
+    "json_response",
+]

--- a/packages/py-fate/src/py_fate/input.py
+++ b/packages/py-fate/src/py_fate/input.py
@@ -1,0 +1,50 @@
+"""Input validation for mutation operations.
+
+Supports three input declarations:
+- `None` — no validation; raw input is passed through.
+- A Pydantic model class — `Model.model_validate(input)`.
+- A plain callable — sync or async function called with the input. May raise to
+  signal validation errors (caught and re-raised as VALIDATION_ERROR).
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from .protocol import FateRequestError
+
+InputSchema = type[BaseModel] | Callable[[Any], Any] | Callable[[Any], Awaitable[Any]] | None
+
+
+async def parse_input(schema: InputSchema, value: Any) -> Any:
+    if schema is None:
+        return value
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        try:
+            return schema.model_validate(value)
+        except ValidationError as exc:
+            raise FateRequestError(
+                "VALIDATION_ERROR",
+                "Invalid mutation input.",
+                issues=exc.errors(include_url=False),
+            ) from exc
+    if callable(schema):
+        try:
+            result = schema(value)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+        except FateRequestError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise FateRequestError(
+                "VALIDATION_ERROR", "Invalid mutation input.", issues=str(exc)
+            ) from exc
+    return value
+
+
+__all__ = ["InputSchema", "parse_input"]

--- a/packages/py-fate/src/py_fate/integrations/__init__.py
+++ b/packages/py-fate/src/py_fate/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Web framework adapters for FateServer.
+
+Each submodule is opt-in and imports its dependency lazily so the core remains
+framework-free.
+"""

--- a/packages/py-fate/src/py_fate/integrations/asgi.py
+++ b/packages/py-fate/src/py_fate/integrations/asgi.py
@@ -1,0 +1,157 @@
+"""Generic ASGI 3.0 adapter.
+
+Mounts a FateServer at any path prefix and routes:
+- POST /<prefix>           -> handle_request
+- GET  /<prefix>/live      -> handle_live_get (SSE)
+- POST /<prefix>/live      -> handle_live_post
+
+Works with any ASGI server (uvicorn, hypercorn, daphne) and any framework that
+can mount a sub-app (Starlette, Litestar, FastAPI via app.mount).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ..http import FateHTTPRequest, FateHTTPResponse, FateSSEResponse
+from ..server import FateServer
+
+ASGIScope = dict[str, Any]
+ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]
+ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+def fate_asgi_app(server: FateServer, *, prefix: str = "") -> ASGIApp:
+    """Return an ASGI app that serves the fate protocol.
+
+    `prefix` is matched against the request path. Routes inside the prefix:
+    - `""`            (POST) -> handle_request
+    - `"/live"`       (GET)  -> handle_live_get
+    - `"/live"`       (POST) -> handle_live_post
+    """
+
+    normalized_prefix = prefix.rstrip("/")
+
+    async def app(scope: ASGIScope, receive: ASGIReceive, send: ASGISend) -> None:
+        if scope["type"] != "http":
+            await _send_error(send, 400, b"Only HTTP requests are supported.")
+            return
+
+        path: str = scope.get("path", "")
+        if normalized_prefix and not path.startswith(normalized_prefix):
+            await _send_error(send, 404, b"Not found.")
+            return
+
+        inner = path[len(normalized_prefix) :] if normalized_prefix else path
+        method: str = scope.get("method", "GET").upper()
+
+        request = _scope_to_request(scope, receive)
+
+        if inner in ("", "/"):
+            if method != "POST":
+                await _send_error(send, 405, b"Method not allowed.")
+                return
+            response = await server.handle_request(request)
+            await _send_response(send, response)
+            return
+
+        if inner in ("/live", "/live/"):
+            if method == "GET":
+                live = await server.handle_live_get(request)
+                if isinstance(live, FateSSEResponse):
+                    await _send_sse(send, live)
+                else:
+                    await _send_response(send, live)
+                return
+            if method == "POST":
+                response = await server.handle_live_post(request)
+                await _send_response(send, response)
+                return
+            await _send_error(send, 405, b"Method not allowed.")
+            return
+
+        await _send_error(send, 404, b"Not found.")
+
+    return app
+
+
+def _scope_to_request(scope: ASGIScope, receive: ASGIReceive) -> FateHTTPRequest:
+    method: str = scope.get("method", "GET")
+    raw_path: str = scope.get("path", "")
+    raw_query: bytes = scope.get("query_string", b"")
+    url = raw_path + (f"?{raw_query.decode('latin-1')}" if raw_query else "")
+
+    headers: dict[str, str] = {}
+    for name, value in scope.get("headers") or []:
+        headers[name.decode("latin-1").lower()] = value.decode("latin-1")
+
+    async def read_body() -> bytes:
+        chunks: list[bytes] = []
+        while True:
+            message = await receive()
+            if message["type"] == "http.request":
+                body = message.get("body") or b""
+                if body:
+                    chunks.append(body)
+                if not message.get("more_body"):
+                    break
+            elif message["type"] == "http.disconnect":
+                break
+        return b"".join(chunks)
+
+    return FateHTTPRequest(method=method, url=url, headers=headers, read_body=read_body)
+
+
+async def _send_response(send: ASGISend, response: FateHTTPResponse) -> None:
+    headers = [
+        (name.encode("latin-1"), value.encode("latin-1"))
+        for name, value in response.headers.items()
+    ]
+    await send(
+        {
+            "type": "http.response.start",
+            "status": response.status,
+            "headers": headers,
+        }
+    )
+    await send({"type": "http.response.body", "body": response.body, "more_body": False})
+
+
+async def _send_sse(send: ASGISend, response: FateSSEResponse) -> None:
+    headers = [
+        (name.encode("latin-1"), value.encode("latin-1"))
+        for name, value in response.headers.items()
+    ]
+    await send(
+        {
+            "type": "http.response.start",
+            "status": response.status,
+            "headers": headers,
+        }
+    )
+    try:
+        async for frame in response.frames:
+            await send({"type": "http.response.body", "body": frame, "more_body": True})
+    finally:
+        if response.on_close is not None:
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                await response.on_close()
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+async def _send_error(send: ASGISend, status: int, body: bytes) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+__all__ = ["fate_asgi_app"]

--- a/packages/py-fate/src/py_fate/integrations/fastapi.py
+++ b/packages/py-fate/src/py_fate/integrations/fastapi.py
@@ -1,0 +1,94 @@
+"""First-class FastAPI integration.
+
+`fate_router(server)` returns a FastAPI `APIRouter` with the three endpoints
+mounted under it. Mount with `app.include_router(router, prefix="/fate")`.
+
+`fastapi` is imported lazily so the core package has no hard FastAPI dependency.
+Install with `pip install py-fate[fastapi]`.
+"""
+
+# NOTE: Intentionally NOT using `from __future__ import annotations` — FastAPI
+# inspects function annotations at runtime to decide how to inject parameters.
+# With deferred (stringified) annotations, FastAPI can't resolve `Request` and
+# tries to bind it as a query parameter (returning 422).
+
+from typing import Any
+
+from ..http import FateHTTPRequest, FateHTTPResponse, FateSSEResponse
+from ..server import FateServer
+
+
+def fate_router(
+    server: FateServer,
+    *,
+    tags: "list[Any] | None" = None,
+) -> Any:
+    """Return an APIRouter that serves the fate protocol.
+
+    Mount it under your preferred prefix:
+
+        from fastapi import FastAPI
+        from py_fate.integrations.fastapi import fate_router
+
+        app = FastAPI()
+        app.include_router(fate_router(fate), prefix="/fate")
+    """
+
+    try:
+        from fastapi import APIRouter, Request
+        from fastapi.responses import Response, StreamingResponse
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "fastapi is required for py_fate.integrations.fastapi — "
+            "install with `pip install py-fate[fastapi]`."
+        ) from exc
+
+    router = APIRouter(tags=tags or ["fate"])
+
+    async def handle(request: Request) -> Response:
+        fate_req = _to_fate_request(request)
+        response = await server.handle_request(fate_req, adapter_context=request)
+        return Response(
+            content=response.body, status_code=response.status, headers=response.headers
+        )
+
+    async def handle_live_get(request: Request) -> Response:
+        fate_req = _to_fate_request(request)
+        result = await server.handle_live_get(fate_req, adapter_context=request)
+        if isinstance(result, FateSSEResponse):
+            return StreamingResponse(
+                result.frames, status_code=result.status, headers=result.headers
+            )
+        assert isinstance(result, FateHTTPResponse)
+        return Response(
+            content=result.body, status_code=result.status, headers=result.headers
+        )
+
+    async def handle_live_post(request: Request) -> Response:
+        fate_req = _to_fate_request(request)
+        response = await server.handle_live_post(fate_req, adapter_context=request)
+        return Response(
+            content=response.body, status_code=response.status, headers=response.headers
+        )
+
+    router.add_api_route("", handle, methods=["POST"], include_in_schema=False)
+    router.add_api_route("/", handle, methods=["POST"])
+    router.add_api_route("/live", handle_live_get, methods=["GET"])
+    router.add_api_route("/live", handle_live_post, methods=["POST"])
+
+    return router
+
+
+def _to_fate_request(request: Any) -> FateHTTPRequest:
+    async def read_body() -> bytes:
+        return await request.body()
+
+    return FateHTTPRequest(
+        method=request.method,
+        url=str(request.url),
+        headers={k.lower(): v for k, v in request.headers.items()},
+        read_body=read_body,
+    )
+
+
+__all__ = ["fate_router"]

--- a/packages/py-fate/src/py_fate/live/__init__.py
+++ b/packages/py-fate/src/py_fate/live/__init__.py
@@ -1,0 +1,22 @@
+"""Live event bus + SSE connection state."""
+
+from .bus import LiveConnectionSourceEvent, LiveEventBus, LiveSourceEvent
+from .memory import InMemoryLiveEventBus, create_live_event_bus
+from .topics import (
+    live_connection_topic,
+    live_entity_topic,
+    live_global_connection_topic,
+    normalize_connection_args,
+)
+
+__all__ = [
+    "InMemoryLiveEventBus",
+    "LiveConnectionSourceEvent",
+    "LiveEventBus",
+    "LiveSourceEvent",
+    "create_live_event_bus",
+    "live_connection_topic",
+    "live_entity_topic",
+    "live_global_connection_topic",
+    "normalize_connection_args",
+]

--- a/packages/py-fate/src/py_fate/live/bus.py
+++ b/packages/py-fate/src/py_fate/live/bus.py
@@ -1,0 +1,123 @@
+"""LiveEventBus abstract base.
+
+This is the pluggable layer that the SSE handler reads from. The in-memory
+implementation is in `memory.py`; a Redis/NATS implementation can replace it
+without touching the rest of the server.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(slots=True)
+class LiveSourceEvent:
+    """Event produced for a `subscribe` (entity) subscription."""
+
+    id: str | int
+    type: Literal["update", "delete"] = "update"
+    data: Any = None
+    changed: list[str] | None = None
+    event_id: str | None = None
+
+
+@dataclass(slots=True)
+class LiveConnectionSourceEvent:
+    """Event produced for a `subscribeConnection` subscription."""
+
+    type: Literal[
+        "appendEdge",
+        "appendNode",
+        "deleteEdge",
+        "insertEdgeAfter",
+        "insertEdgeBefore",
+        "prependEdge",
+        "prependNode",
+        "invalidate",
+    ]
+    id: str | int | None = None
+    node: Any = None
+    node_type: str | None = None
+    cursor: str | None = None
+    target_cursor: str | None = None
+    event_id: str | None = None
+
+
+@dataclass(slots=True)
+class ConnectionTarget:
+    procedure: str
+    args: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class SubscribeOptions:
+    last_event_id: str | None = None
+
+
+@dataclass(slots=True)
+class _ConnectionEvent:
+    target: ConnectionTarget
+    event: LiveConnectionSourceEvent = field(default_factory=lambda: LiveConnectionSourceEvent(type="invalidate"))
+
+
+class LiveEventBus(ABC):
+    """Pluggable event bus for live subscriptions."""
+
+    @abstractmethod
+    async def emit(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        data: Any = None,
+        changed: list[str] | None = None,
+        event_id: str | None = None,
+        event_type: Literal["update", "delete"] = "update",
+    ) -> None: ...
+
+    @abstractmethod
+    async def delete(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        event_id: str | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    async def emit_connection(
+        self,
+        procedure: str,
+        event: LiveConnectionSourceEvent,
+        *,
+        args: dict[str, Any] | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    def subscribe(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        options: SubscribeOptions | None = None,
+    ) -> AsyncIterator[LiveSourceEvent]: ...
+
+    @abstractmethod
+    def subscribe_connection(
+        self,
+        target: ConnectionTarget,
+        *,
+        options: SubscribeOptions | None = None,
+    ) -> AsyncIterator[LiveConnectionSourceEvent]: ...
+
+
+__all__ = [
+    "ConnectionTarget",
+    "LiveConnectionSourceEvent",
+    "LiveEventBus",
+    "LiveSourceEvent",
+    "SubscribeOptions",
+]

--- a/packages/py-fate/src/py_fate/live/connection.py
+++ b/packages/py-fate/src/py_fate/live/connection.py
@@ -1,0 +1,78 @@
+"""Per-connection live state.
+
+Tracks a single SSE client: outbound message queue, active subscription tasks
+keyed by operation id, and an atomic close flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class LiveConnection:
+    connection_id: str
+    outbox: asyncio.Queue[Any]
+    subscriptions: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    closed: bool = False
+    last_event_ids: dict[str, str] = field(default_factory=dict)
+    max_queue_size: int = 1000
+
+    def enqueue(self, frame: Any) -> bool:
+        """Push a frame onto the outbox.
+
+        Returns False if the connection's queue is full (caller should close it).
+        """
+
+        if self.closed:
+            return False
+        if self.outbox.qsize() >= self.max_queue_size:
+            return False
+        self.outbox.put_nowait(frame)
+        return True
+
+    def add_subscription(self, op_id: str, task: asyncio.Task[None]) -> None:
+        existing = self.subscriptions.pop(op_id, None)
+        if existing is not None:
+            existing.cancel()
+        self.subscriptions[op_id] = task
+
+    def cancel_subscription(self, op_id: str) -> None:
+        task = self.subscriptions.pop(op_id, None)
+        if task is not None:
+            task.cancel()
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        for task in list(self.subscriptions.values()):
+            task.cancel()
+        for task in list(self.subscriptions.values()):
+            with contextlib.suppress(BaseException):
+                await task
+        self.subscriptions.clear()
+
+
+class LiveConnectionRegistry:
+    """Tracks active live connections by id."""
+
+    def __init__(self) -> None:
+        self._connections: dict[str, LiveConnection] = {}
+
+    def register(self, connection: LiveConnection) -> None:
+        self._connections[connection.connection_id] = connection
+
+    def get(self, connection_id: str) -> LiveConnection | None:
+        return self._connections.get(connection_id)
+
+    async def remove(self, connection_id: str) -> None:
+        connection = self._connections.pop(connection_id, None)
+        if connection is not None:
+            await connection.close()
+
+
+__all__ = ["LiveConnection", "LiveConnectionRegistry"]

--- a/packages/py-fate/src/py_fate/live/memory.py
+++ b/packages/py-fate/src/py_fate/live/memory.py
@@ -1,0 +1,150 @@
+"""In-memory `LiveEventBus` implementation using asyncio fanout.
+
+Single-process only. Drop-in replacement for production: write another
+`LiveEventBus` subclass that backs onto Redis/NATS/Kafka.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import suppress
+from typing import Any, Literal
+
+from .bus import (
+    ConnectionTarget,
+    LiveConnectionSourceEvent,
+    LiveEventBus,
+    LiveSourceEvent,
+    SubscribeOptions,
+)
+from .topics import live_connection_topic, live_entity_topic, live_global_connection_topic
+
+
+class _Subscriber:
+    __slots__ = ("queue",)
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[Any] = asyncio.Queue()
+
+
+class InMemoryLiveEventBus(LiveEventBus):
+    """Default in-process bus.
+
+    Forwards `event_id` to subscribers, but does not replay events after reconnects.
+    All operations are synchronous (no asyncio.Lock) — safe because the asyncio
+    event loop is single-threaded and we only mutate state from inside it.
+    """
+
+    def __init__(self) -> None:
+        self._entity_subs: dict[str, set[_Subscriber]] = {}
+        self._connection_subs: dict[str, set[_Subscriber]] = {}
+
+    # ---------- emit ----------
+
+    async def emit(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        data: Any = None,
+        changed: list[str] | None = None,
+        event_id: str | None = None,
+        event_type: Literal["update", "delete"] = "update",
+    ) -> None:
+        event = LiveSourceEvent(
+            id=entity_id,
+            type=event_type,
+            data=data,
+            changed=list(changed) if changed else None,
+            event_id=event_id,
+        )
+        topic = live_entity_topic(type_name, entity_id)
+        self._publish(self._entity_subs, topic, event)
+
+    async def delete(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        event_id: str | None = None,
+    ) -> None:
+        await self.emit(type_name, entity_id, event_id=event_id, event_type="delete")
+
+    async def emit_connection(
+        self,
+        procedure: str,
+        event: LiveConnectionSourceEvent,
+        *,
+        args: dict[str, Any] | None = None,
+    ) -> None:
+        scoped = live_connection_topic(procedure, args)
+        wildcard = live_global_connection_topic(procedure)
+        self._publish(self._connection_subs, scoped, event)
+        if scoped != wildcard:
+            self._publish(self._connection_subs, wildcard, event)
+
+    def _publish(
+        self, subs_map: dict[str, set[_Subscriber]], topic: str, payload: Any
+    ) -> None:
+        for sub in list(subs_map.get(topic, ())):
+            sub.queue.put_nowait(payload)
+
+    # ---------- subscribe ----------
+
+    def _add_sub(self, subs_map: dict[str, set[_Subscriber]], topic: str) -> _Subscriber:
+        sub = _Subscriber()
+        subs_map.setdefault(topic, set()).add(sub)
+        return sub
+
+    def _remove_sub(
+        self, subs_map: dict[str, set[_Subscriber]], topic: str, sub: _Subscriber
+    ) -> None:
+        bucket = subs_map.get(topic)
+        if bucket is not None:
+            bucket.discard(sub)
+            if not bucket:
+                subs_map.pop(topic, None)
+
+    def subscribe(
+        self,
+        type_name: str,
+        entity_id: str | int,
+        *,
+        options: SubscribeOptions | None = None,
+    ) -> AsyncIterator[LiveSourceEvent]:
+        del options  # in-memory bus has no replay buffer
+        topic = live_entity_topic(type_name, entity_id)
+        sub = self._add_sub(self._entity_subs, topic)
+        return self._iter(self._entity_subs, topic, sub)
+
+    def subscribe_connection(
+        self,
+        target: ConnectionTarget,
+        *,
+        options: SubscribeOptions | None = None,
+    ) -> AsyncIterator[LiveConnectionSourceEvent]:
+        del options
+        topic = live_connection_topic(target.procedure, target.args)
+        sub = self._add_sub(self._connection_subs, topic)
+        return self._iter(self._connection_subs, topic, sub)
+
+    async def _iter(
+        self,
+        subs_map: dict[str, set[_Subscriber]],
+        topic: str,
+        sub: _Subscriber,
+    ) -> AsyncIterator[Any]:
+        try:
+            while True:
+                yield await sub.queue.get()
+        finally:
+            with suppress(Exception):
+                self._remove_sub(subs_map, topic, sub)
+
+
+def create_live_event_bus() -> InMemoryLiveEventBus:
+    return InMemoryLiveEventBus()
+
+
+__all__ = ["InMemoryLiveEventBus", "create_live_event_bus"]

--- a/packages/py-fate/src/py_fate/live/topics.py
+++ b/packages/py-fate/src/py_fate/live/topics.py
@@ -1,0 +1,51 @@
+"""Topic naming — mirrors `packages/fate/src/liveTopics.ts`."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+from urllib.parse import quote
+
+
+def _quote(value: str | int) -> str:
+    return quote(str(value), safe="")
+
+
+PAGINATION_KEYS = frozenset({"after", "before", "first", "last"})
+
+
+def normalize_connection_args(args: dict[str, Any] | None) -> dict[str, Any]:
+    """Drop pagination args; the rest of the args identifies a subscription topic."""
+
+    if not args:
+        return {}
+    return {k: v for k, v in args.items() if k not in PAGINATION_KEYS}
+
+
+def _hash_args(args: dict[str, Any]) -> str:
+    if not args:
+        return "0"
+    canonical = json.dumps(args, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha1(canonical.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+
+
+def live_entity_topic(type_name: str, entity_id: str | int) -> str:
+    return f"entity:{_quote(type_name)}:{_quote(entity_id)}"
+
+
+def live_connection_topic(procedure: str, args: dict[str, Any] | None = None) -> str:
+    digest = _hash_args(normalize_connection_args(args))
+    return f"connection:{_quote(procedure)}:{_quote(digest)}"
+
+
+def live_global_connection_topic(procedure: str) -> str:
+    return f"connection:{_quote(procedure)}:*"
+
+
+__all__ = [
+    "live_connection_topic",
+    "live_entity_topic",
+    "live_global_connection_topic",
+    "normalize_connection_args",
+]

--- a/packages/py-fate/src/py_fate/protocol.py
+++ b/packages/py-fate/src/py_fate/protocol.py
@@ -1,0 +1,337 @@
+"""Wire-protocol types and helpers for the fate protocol (version 1).
+
+Mirrors `packages/fate/src/protocol.ts`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FateProtocolVersion = Literal[1]
+PROTOCOL_VERSION: FateProtocolVersion = 1
+
+FateOperationKind = Literal["byId", "list", "mutation", "query"]
+
+FateProtocolErrorCode = Literal[
+    "BAD_REQUEST",
+    "FORBIDDEN",
+    "INTERNAL_ERROR",
+    "NOT_FOUND",
+    "UNAUTHORIZED",
+    "VALIDATION_ERROR",
+]
+
+
+_STATUS_BY_CODE: dict[FateProtocolErrorCode, int] = {
+    "BAD_REQUEST": 400,
+    "VALIDATION_ERROR": 400,
+    "UNAUTHORIZED": 401,
+    "FORBIDDEN": 403,
+    "NOT_FOUND": 404,
+    "INTERNAL_ERROR": 500,
+}
+
+
+def status_from_error_code(code: FateProtocolErrorCode) -> int:
+    return _STATUS_BY_CODE[code]
+
+
+def error_code_from_status(status: int) -> FateProtocolErrorCode:
+    if status == 400:
+        return "BAD_REQUEST"
+    if status == 401:
+        return "UNAUTHORIZED"
+    if status == 403:
+        return "FORBIDDEN"
+    if status == 404:
+        return "NOT_FOUND"
+    return "INTERNAL_ERROR"
+
+
+class FateProtocolError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: FateProtocolErrorCode
+    message: str
+    issues: Any | None = None
+    path: str | None = None
+
+
+class FateRequestError(Exception):
+    """Exception thrown by handlers to map to a protocol error."""
+
+    code: FateProtocolErrorCode
+    message: str
+    issues: Any | None
+    path: str | None
+    status: int
+
+    def __init__(
+        self,
+        code: FateProtocolErrorCode,
+        message: str,
+        *,
+        issues: Any | None = None,
+        status: int | None = None,
+        path: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.issues = issues
+        self.path = path
+        self.status = status if status is not None else status_from_error_code(code)
+
+
+def to_protocol_error(error: BaseException) -> FateProtocolError:
+    if isinstance(error, FateRequestError):
+        return FateProtocolError(
+            code=error.code,
+            message=error.message,
+            issues=error.issues,
+            path=error.path,
+        )
+    return FateProtocolError(code="INTERNAL_ERROR", message="Internal server error.")
+
+
+class FateOperation(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    kind: FateOperationKind
+    select: list[str]
+    args: dict[str, Any] | None = None
+    ids: list[str | int] | None = None
+    input: Any | None = None
+    name: str | None = None
+    type: str | None = None
+
+
+class FateProtocolRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: FateProtocolVersion
+    operations: list[FateOperation]
+
+
+class FateOperationOk(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    ok: Literal[True] = True
+    data: Any = None
+
+
+class FateOperationErr(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    ok: Literal[False] = False
+    error: FateProtocolError
+
+
+FateOperationResult = FateOperationOk | FateOperationErr
+
+
+class FateProtocolResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: FateProtocolVersion = PROTOCOL_VERSION
+    results: list[FateOperationResult]
+
+
+class Pagination(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hasNext: bool
+    hasPrevious: bool
+    nextCursor: str | None = None
+    previousCursor: str | None = None
+
+
+class ConnectionItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cursor: str | None = None
+    node: Any
+
+
+class FateConnectionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ConnectionItem]
+    pagination: Pagination
+
+
+# ---------- Live (SSE) ----------
+
+
+class FateLiveDataEvent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    data: Any
+    delete: Literal[False] | None = None
+    select: list[str] | None = None
+    type: Literal["data", "update"] | None = None
+
+
+class FateLiveDeleteEvent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    delete: Literal[True] = True
+    id: str | int | None = None
+    type: Literal["delete"] | None = None
+
+
+FateLiveEvent = FateLiveDataEvent | FateLiveDeleteEvent
+
+
+class FateLiveConnectionEdgeEvent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal[
+        "appendEdge",
+        "appendNode",
+        "insertEdgeAfter",
+        "insertEdgeBefore",
+        "prependEdge",
+        "prependNode",
+    ]
+    edge: dict[str, Any]
+    nodeType: str
+    targetCursor: str | None = None
+
+
+class FateLiveConnectionDeleteEvent(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["deleteEdge"] = "deleteEdge"
+    id: str | int
+    nodeType: str
+
+
+class FateLiveConnectionInvalidateEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["invalidate"] = "invalidate"
+
+
+FateLiveConnectionEvent = (
+    FateLiveConnectionEdgeEvent
+    | FateLiveConnectionDeleteEvent
+    | FateLiveConnectionInvalidateEvent
+)
+
+
+class FateLiveSubscribeOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["subscribe"]
+    type: str
+    entityId: str | int
+    select: list[str]
+    args: dict[str, Any] | None = None
+    lastEventId: str | None = None
+
+
+class FateLiveConnectionSubscribeOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["subscribeConnection"]
+    type: str
+    procedure: str
+    select: list[str]
+    args: dict[str, Any] | None = None
+    selectionArgs: dict[str, Any] | None = None
+    lastEventId: str | None = None
+
+
+class FateLiveUnsubscribeOperation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["unsubscribe"]
+
+
+FateLiveControlOperation = (
+    FateLiveSubscribeOperation
+    | FateLiveConnectionSubscribeOperation
+    | FateLiveUnsubscribeOperation
+)
+
+
+class FateLiveControlRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: FateProtocolVersion
+    connectionId: str
+    operations: list[FateLiveControlOperation] = Field(default_factory=list)
+
+
+class FateLiveMessageNext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["next"] = "next"
+    event: FateLiveEvent
+
+
+class FateLiveMessageConnection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["connection"] = "connection"
+    event: FateLiveConnectionEvent
+
+
+class FateLiveMessageError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: Literal["error"] = "error"
+    error: FateProtocolError
+
+
+FateLiveMessage = FateLiveMessageNext | FateLiveMessageConnection | FateLiveMessageError
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "ConnectionItem",
+    "FateConnectionResult",
+    "FateLiveConnectionDeleteEvent",
+    "FateLiveConnectionEdgeEvent",
+    "FateLiveConnectionEvent",
+    "FateLiveConnectionInvalidateEvent",
+    "FateLiveConnectionSubscribeOperation",
+    "FateLiveControlOperation",
+    "FateLiveControlRequest",
+    "FateLiveDataEvent",
+    "FateLiveDeleteEvent",
+    "FateLiveEvent",
+    "FateLiveMessage",
+    "FateLiveMessageConnection",
+    "FateLiveMessageError",
+    "FateLiveMessageNext",
+    "FateLiveSubscribeOperation",
+    "FateLiveUnsubscribeOperation",
+    "FateOperation",
+    "FateOperationErr",
+    "FateOperationKind",
+    "FateOperationOk",
+    "FateOperationResult",
+    "FateProtocolError",
+    "FateProtocolErrorCode",
+    "FateProtocolRequest",
+    "FateProtocolResponse",
+    "FateProtocolVersion",
+    "FateRequestError",
+    "Pagination",
+    "error_code_from_status",
+    "status_from_error_code",
+    "to_protocol_error",
+]

--- a/packages/py-fate/src/py_fate/selection.py
+++ b/packages/py-fate/src/py_fate/selection.py
@@ -1,0 +1,127 @@
+"""Helpers for parsing and scoping flat dotted selection paths.
+
+The wire protocol sends `select: string[]` where each entry is a dotted path:
+    ["id", "title", "author.id", "author.name", "comments.items.node.id"]
+
+These helpers convert that to a nested tree and let callers scope it to a relation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Union, cast
+
+SelectionTree = dict[str, Union[bool, "SelectionTree"]]
+
+
+def parse_paths(paths: Iterable[str]) -> SelectionTree:
+    """Convert flat dotted paths into a nested selection tree.
+
+    Leaves are True; inner nodes are SelectionTree.
+    """
+
+    tree: SelectionTree = {}
+    for raw in paths:
+        if not raw:
+            continue
+        parts = raw.split(".")
+        node: SelectionTree = tree
+        for part in parts[:-1]:
+            existing = node.get(part)
+            if not isinstance(existing, dict):
+                existing = {}
+                node[part] = existing
+            node = existing
+        last = parts[-1]
+        if last not in node:
+            node[last] = True
+    return tree
+
+
+def tree_to_paths(tree: SelectionTree, prefix: str = "") -> list[str]:
+    """Inverse of `parse_paths`."""
+
+    out: list[str] = []
+    for key, value in tree.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if value is True:
+            out.append(path)
+        elif isinstance(value, dict):
+            out.extend(tree_to_paths(value, path))
+    return out
+
+
+def subselect(paths: Iterable[str], prefix: str) -> list[str]:
+    """Return all paths under `prefix`, stripped of the prefix.
+
+    Examples:
+        subselect(["id", "author.id", "author.name"], "author") -> ["id", "name"]
+    """
+
+    head = f"{prefix}."
+    out: list[str] = []
+    for raw in paths:
+        if raw == prefix:
+            continue
+        if raw.startswith(head):
+            out.append(raw[len(head) :])
+    return out
+
+
+def has_path(paths: Iterable[str], target: str) -> bool:
+    """Return True if `target` (or any descendant of `target`) is selected."""
+
+    head = f"{target}."
+    return any(p == target or p.startswith(head) for p in paths)
+
+
+def paths_intersect(left: str, right: str) -> bool:
+    """Return True if one path is a prefix of (or equal to) the other.
+
+    Mirrors the TS helper used by live filtering.
+    """
+
+    return left == right or left.startswith(f"{right}.") or right.startswith(f"{left}.")
+
+
+def filter_by_paths(value: object, paths: Iterable[str]) -> object:
+    """Return a deep copy of `value` containing only the dotted paths in `paths`.
+
+    - Dicts: only requested keys are kept.
+    - Lists: each item is filtered by the same subselection.
+    - For list-shaped relations matching the connection contract
+      ({"items": [...], "pagination": {...}}), nested paths under "items.node"
+      or "items" still work because we recurse.
+    """
+
+    tree = parse_paths(paths)
+    return _filter(value, tree)
+
+
+def _filter(value: object, tree: SelectionTree | bool) -> object:
+    if tree is True:
+        return value
+    if not isinstance(tree, dict):
+        return value
+    if isinstance(value, dict):
+        source = cast(dict[str, object], value)
+        out: dict[str, object] = {}
+        for key, subtree in tree.items():
+            if key in source:
+                out[key] = _filter(source[key], subtree)
+        return out
+    if isinstance(value, list):
+        items = cast(list[object], value)
+        return [_filter(item, tree) for item in items]
+    return value
+
+
+__all__ = [
+    "SelectionTree",
+    "filter_by_paths",
+    "has_path",
+    "parse_paths",
+    "paths_intersect",
+    "subselect",
+    "tree_to_paths",
+]

--- a/packages/py-fate/src/py_fate/server.py
+++ b/packages/py-fate/src/py_fate/server.py
@@ -1,0 +1,499 @@
+"""FateServer — the framework-agnostic core.
+
+`create_fate_server` returns a `FateServer` with three async entry points:
+- `handle_request(request)` — POST /<prefix> dispatch
+- `handle_live_get(request)` — GET /<prefix>/live SSE stream
+- `handle_live_post(request)` — POST /<prefix>/live subscription control
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+import json
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import ValidationError
+
+from .data_view import DataView, ListField, as_view
+from .executor import (
+    ListDefinition,
+    MutationDefinition,
+    QueryDefinition,
+    ServerRegistry,
+    execute_operation,
+)
+from .http import (
+    FateHTTPRequest,
+    FateHTTPResponse,
+    FateSSEResponse,
+    json_response,
+)
+from .live.bus import (
+    ConnectionTarget,
+    LiveConnectionSourceEvent,
+    LiveEventBus,
+    LiveSourceEvent,
+    SubscribeOptions,
+)
+from .live.connection import LiveConnection, LiveConnectionRegistry
+from .protocol import (
+    FateLiveConnectionDeleteEvent,
+    FateLiveConnectionEdgeEvent,
+    FateLiveConnectionInvalidateEvent,
+    FateLiveConnectionSubscribeOperation,
+    FateLiveControlRequest,
+    FateLiveDataEvent,
+    FateLiveDeleteEvent,
+    FateLiveMessage,
+    FateLiveMessageConnection,
+    FateLiveMessageError,
+    FateLiveMessageNext,
+    FateLiveSubscribeOperation,
+    FateLiveUnsubscribeOperation,
+    FateOperationErr,
+    FateOperationOk,
+    FateProtocolRequest,
+    FateProtocolResponse,
+    FateRequestError,
+    status_from_error_code,
+    to_protocol_error,
+)
+from .selection import filter_by_paths, subselect
+from .source import ByIdRequest, SourceAdapter
+from .sse import SSE_HEADERS, sse_comment, sse_frame
+
+ContextFactory = Callable[..., Awaitable[Any] | Any]
+
+HEARTBEAT_SECONDS = 25.0
+
+
+@dataclass(slots=True)
+class _ServerConfig:
+    queries: Mapping[str, QueryDefinition] | None = None
+    lists: Mapping[str, ListDefinition] | None = None
+    mutations: Mapping[str, MutationDefinition] | None = None
+    roots: Mapping[str, type[DataView[Any]] | DataView[Any] | ListField] | None = None
+    sources: SourceAdapter | None = None
+    live: LiveEventBus | None = None
+    context: ContextFactory | None = None
+    max_queue_size: int = 1000
+
+
+class FateServer:
+    """Framework-agnostic fate server.
+
+    Construct one with `create_fate_server(...)` and call `handle_request` /
+    `handle_live_get` / `handle_live_post` from your web framework adapter.
+    """
+
+    def __init__(self, config: _ServerConfig) -> None:
+        normalized_roots: dict[str, DataView[Any] | ListField] = {
+            name: (root if isinstance(root, ListField) else as_view(root))
+            for name, root in (config.roots or {}).items()
+        }
+        self._registry = ServerRegistry(
+            queries=dict(config.queries or {}),
+            lists=dict(config.lists or {}),
+            mutations=dict(config.mutations or {}),
+            roots=normalized_roots,
+            sources=config.sources,
+        )
+        self._context_factory = config.context
+        self._live_bus = config.live
+        self._connections = LiveConnectionRegistry()
+        self._max_queue_size = config.max_queue_size
+
+    @property
+    def live_bus(self) -> LiveEventBus | None:
+        return self._live_bus
+
+    @property
+    def registry(self) -> ServerRegistry:
+        return self._registry
+
+    # ---------- context ----------
+
+    async def _build_context(self, request: FateHTTPRequest, adapter_context: Any) -> Any:
+        if self._context_factory is None:
+            return None
+        result = self._context_factory(request=request, adapter_context=adapter_context)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    # ---------- POST /<prefix> ----------
+
+    async def handle_request(
+        self, request: FateHTTPRequest, *, adapter_context: Any = None
+    ) -> FateHTTPResponse:
+        try:
+            raw = await request.json()
+            try:
+                payload = FateProtocolRequest.model_validate(raw)
+            except ValidationError as exc:
+                raise FateRequestError(
+                    "BAD_REQUEST", "Invalid Fate protocol request.", issues=exc.errors(include_url=False)
+                ) from exc
+
+            ctx = await self._build_context(request, adapter_context)
+            results = await asyncio.gather(
+                *(execute_operation(op, ctx, self._registry) for op in payload.operations)
+            )
+            response = FateProtocolResponse(results=results)
+            return json_response(response.model_dump(exclude_none=True))
+        except FateRequestError as exc:
+            return _error_envelope(exc, operation_id="request")
+        except json.JSONDecodeError as exc:
+            return _error_envelope(
+                FateRequestError("BAD_REQUEST", "Invalid JSON body.", issues=str(exc)),
+                operation_id="request",
+            )
+        except Exception:  # noqa: BLE001
+            return _error_envelope(
+                FateRequestError("INTERNAL_ERROR", "Internal server error."),
+                operation_id="request",
+            )
+
+    # ---------- GET /<prefix>/live ----------
+
+    async def handle_live_get(
+        self, request: FateHTTPRequest, *, adapter_context: Any = None
+    ) -> FateSSEResponse | FateHTTPResponse:
+        if self._live_bus is None:
+            return _error_envelope(
+                FateRequestError("NOT_FOUND", "Live views are not enabled."),
+                operation_id="live",
+            )
+
+        connection_id = _query_param(request.url, "connectionId")
+        if not connection_id:
+            return _error_envelope(
+                FateRequestError("BAD_REQUEST", "Invalid Fate live request."),
+                operation_id="live",
+            )
+
+        outbox: asyncio.Queue[bytes | None] = asyncio.Queue()
+        connection = LiveConnection(
+            connection_id=connection_id,
+            outbox=outbox,
+            max_queue_size=self._max_queue_size,
+        )
+        self._connections.register(connection)
+
+        async def stream() -> AsyncIterator[bytes]:
+            yield sse_comment("connected")
+            heartbeat = asyncio.create_task(_heartbeat(outbox))
+            try:
+                while True:
+                    frame = await outbox.get()
+                    if frame is None:
+                        break
+                    yield frame
+            finally:
+                heartbeat.cancel()
+                with contextlib.suppress(BaseException):
+                    await heartbeat
+                await self._connections.remove(connection_id)
+
+        async def on_close() -> None:
+            await self._connections.remove(connection_id)
+
+        return FateSSEResponse(
+            status=200, headers=dict(SSE_HEADERS), frames=stream(), on_close=on_close
+        )
+
+    # ---------- POST /<prefix>/live ----------
+
+    async def handle_live_post(
+        self, request: FateHTTPRequest, *, adapter_context: Any = None
+    ) -> FateHTTPResponse:
+        if self._live_bus is None:
+            return _error_envelope(
+                FateRequestError("NOT_FOUND", "Live views are not enabled."),
+                operation_id="live",
+            )
+
+        try:
+            raw = await request.json()
+            try:
+                payload = FateLiveControlRequest.model_validate(raw)
+            except ValidationError as exc:
+                raise FateRequestError(
+                    "BAD_REQUEST",
+                    "Invalid Fate live request.",
+                    issues=exc.errors(include_url=False),
+                ) from exc
+
+            connection = self._connections.get(payload.connectionId)
+            if connection is None or connection.closed:
+                raise FateRequestError("NOT_FOUND", "Live connection not found.")
+
+            ctx = await self._build_context(request, adapter_context)
+            results: list[FateOperationOk | FateOperationErr] = []
+            for op in payload.operations:
+                try:
+                    self._apply_control_op(connection, op, ctx)
+                    results.append(FateOperationOk(id=op.id, data=None))
+                except BaseException as exc:  # noqa: BLE001
+                    if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                        raise
+                    results.append(FateOperationErr(id=op.id, error=to_protocol_error(exc)))
+            response = FateProtocolResponse(results=results)
+            return json_response(response.model_dump(exclude_none=True))
+        except FateRequestError as exc:
+            return _error_envelope(exc, operation_id="live")
+        except Exception:  # noqa: BLE001
+            return _error_envelope(
+                FateRequestError("INTERNAL_ERROR", "Internal server error."),
+                operation_id="live",
+            )
+
+    # ---------- subscriptions ----------
+
+    def _apply_control_op(
+        self,
+        connection: LiveConnection,
+        op: FateLiveSubscribeOperation
+        | FateLiveConnectionSubscribeOperation
+        | FateLiveUnsubscribeOperation,
+        ctx: Any,
+    ) -> None:
+        if isinstance(op, FateLiveUnsubscribeOperation):
+            connection.cancel_subscription(op.id)
+            return
+
+        if self._live_bus is None:  # pragma: no cover — guarded above
+            raise FateRequestError("NOT_FOUND", "Live views are not enabled.")
+
+        if isinstance(op, FateLiveSubscribeOperation):
+            iterator = self._live_bus.subscribe(
+                op.type,
+                op.entityId,
+                options=SubscribeOptions(last_event_id=op.lastEventId),
+            )
+            task = asyncio.create_task(
+                self._run_entity_subscription(connection, op, ctx, iterator),
+                name=f"fate-live-sub-{op.id}",
+            )
+            connection.add_subscription(op.id, task)
+            return
+
+        # FateLiveConnectionSubscribeOperation
+        target = ConnectionTarget(procedure=op.procedure, args=op.args)
+        iterator = self._live_bus.subscribe_connection(
+            target, options=SubscribeOptions(last_event_id=op.lastEventId)
+        )
+        task = asyncio.create_task(
+            self._run_connection_subscription(connection, op, ctx, iterator),
+            name=f"fate-live-conn-{op.id}",
+        )
+        connection.add_subscription(op.id, task)
+
+    async def _run_entity_subscription(
+        self,
+        connection: LiveConnection,
+        op: FateLiveSubscribeOperation,
+        ctx: Any,
+        iterator: AsyncIterator[LiveSourceEvent],
+    ) -> None:
+        assert self._live_bus is not None
+        try:
+            async for event in iterator:
+                message = await self._build_entity_message(op, event, ctx)
+                if not connection.enqueue(sse_frame(message, event_id=event.event_id)):
+                    await self._close_overflow(connection)
+                    return
+                if event.event_id:
+                    connection.last_event_ids[op.id] = event.event_id
+        except asyncio.CancelledError:
+            return
+        except BaseException as exc:  # noqa: BLE001
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+            self._enqueue_error(connection, op.id, exc)
+
+    async def _run_connection_subscription(
+        self,
+        connection: LiveConnection,
+        op: FateLiveConnectionSubscribeOperation,
+        ctx: Any,
+        iterator: AsyncIterator[LiveConnectionSourceEvent],
+    ) -> None:
+        assert self._live_bus is not None
+        try:
+            async for event in iterator:
+                message = await self._build_connection_message(op, event, ctx)
+                if not connection.enqueue(sse_frame(message, event_id=event.event_id)):
+                    await self._close_overflow(connection)
+                    return
+                if event.event_id:
+                    connection.last_event_ids[op.id] = event.event_id
+        except asyncio.CancelledError:
+            return
+        except BaseException as exc:  # noqa: BLE001
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+            self._enqueue_error(connection, op.id, exc)
+
+    async def _build_entity_message(
+        self,
+        op: FateLiveSubscribeOperation,
+        event: LiveSourceEvent,
+        ctx: Any,
+    ) -> FateLiveMessage:
+        if event.type == "delete":
+            return FateLiveMessageNext(
+                id=op.id, event=FateLiveDeleteEvent(delete=True, id=event.id)
+            )
+        data = event.data
+        if data is None and self._registry.sources is not None:
+            try:
+                fetched = await self._registry.sources.resolve_by_ids(
+                    ByIdRequest(
+                        ctx=ctx,
+                        type=op.type,
+                        ids=[event.id],
+                        select=list(op.select),
+                    )
+                )
+                data = fetched[0] if fetched else None
+            except Exception:  # noqa: BLE001
+                data = None
+        if data is None:
+            return FateLiveMessageNext(
+                id=op.id, event=FateLiveDeleteEvent(delete=True, id=event.id)
+            )
+        filtered = filter_by_paths(data, op.select)
+        return FateLiveMessageNext(
+            id=op.id,
+            event=FateLiveDataEvent(data=filtered, select=event.changed),
+        )
+
+    async def _build_connection_message(
+        self,
+        op: FateLiveConnectionSubscribeOperation,
+        event: LiveConnectionSourceEvent,
+        ctx: Any,
+    ) -> FateLiveMessage:
+        if event.type == "invalidate":
+            return FateLiveMessageConnection(
+                id=op.id, event=FateLiveConnectionInvalidateEvent()
+            )
+        if event.type == "deleteEdge":
+            return FateLiveMessageConnection(
+                id=op.id,
+                event=FateLiveConnectionDeleteEvent(
+                    id=event.id if event.id is not None else "",
+                    nodeType=event.node_type or op.type,
+                ),
+            )
+
+        node = event.node
+        if node is None and event.id is not None and self._registry.sources is not None:
+            node_select = subselect(op.select, "items.node")
+            fetched = await self._registry.sources.resolve_by_ids(
+                ByIdRequest(
+                    ctx=ctx,
+                    type=event.node_type or op.type,
+                    ids=[event.id],
+                    select=node_select,
+                )
+            )
+            node = fetched[0] if fetched else None
+        elif node is not None:
+            node_select = subselect(op.select, "items.node")
+            node = filter_by_paths(node, node_select)
+
+        return FateLiveMessageConnection(
+            id=op.id,
+            event=FateLiveConnectionEdgeEvent(
+                type=event.type,
+                nodeType=event.node_type or op.type,
+                edge={"cursor": event.cursor, "node": node},
+                targetCursor=event.target_cursor,
+            ),
+        )
+
+    def _enqueue_error(
+        self, connection: LiveConnection, op_id: str, error: BaseException
+    ) -> None:
+        msg = FateLiveMessageError(id=op_id, error=to_protocol_error(error))
+        connection.enqueue(sse_frame(msg))
+
+    async def _close_overflow(self, connection: LiveConnection) -> None:
+        # signal stream end + drop the connection
+        connection.outbox.put_nowait(None)  # type: ignore[arg-type]
+        await self._connections.remove(connection.connection_id)
+
+
+def create_fate_server(
+    *,
+    queries: Mapping[str, QueryDefinition] | None = None,
+    lists: Mapping[str, ListDefinition] | None = None,
+    mutations: Mapping[str, MutationDefinition] | None = None,
+    roots: Mapping[str, type[DataView[Any]] | DataView[Any] | ListField] | None = None,
+    sources: SourceAdapter | None = None,
+    live: LiveEventBus | None = None,
+    context: ContextFactory | None = None,
+    max_queue_size: int = 1000,
+) -> FateServer:
+    return FateServer(
+        _ServerConfig(
+            queries=queries,
+            lists=lists,
+            mutations=mutations,
+            roots=roots,
+            sources=sources,
+            live=live,
+            context=context,
+            max_queue_size=max_queue_size,
+        )
+    )
+
+
+# ---------- helpers ----------
+
+
+def _error_envelope(exc: FateRequestError, *, operation_id: str) -> FateHTTPResponse:
+    response = FateProtocolResponse(
+        results=[FateOperationErr(id=operation_id, error=to_protocol_error(exc))]
+    )
+    return json_response(
+        response.model_dump(exclude_none=True),
+        status=status_from_error_code(exc.code),
+    )
+
+
+def _query_param(url: str, key: str) -> str | None:
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(url)
+    values = parse_qs(parsed.query).get(key)
+    return values[0] if values else None
+
+
+async def _heartbeat(outbox: asyncio.Queue[bytes | None]) -> None:
+    try:
+        while True:
+            await asyncio.sleep(HEARTBEAT_SECONDS)
+            outbox.put_nowait(sse_comment("heartbeat"))
+    except asyncio.CancelledError:
+        return
+
+
+def new_connection_id() -> str:
+    """Helper for tests / examples to generate UUID v4 connection ids."""
+
+    return str(uuid.uuid4())
+
+
+__all__ = [
+    "FateServer",
+    "create_fate_server",
+    "new_connection_id",
+]

--- a/packages/py-fate/src/py_fate/source.py
+++ b/packages/py-fate/src/py_fate/source.py
@@ -1,0 +1,250 @@
+"""Source adapter interface.
+
+A source adapter is the bridge between fate's data views and a user's storage
+layer. fate calls into the adapter to materialize entities for `byId` and list
+operations, plus to follow relations declared in DataViews.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from typing import Any, Generic, cast
+
+from .connection import resolve_connection
+from .data_view import DataView, EntityT, ListField, as_view
+from .protocol import FateConnectionResult, FateRequestError
+from .selection import has_path, subselect
+
+
+@dataclass(slots=True)
+class ByIdRequest(Generic[EntityT]):
+    """A typed `byId` request. The `EntityT` parameter flows back to the caller
+    as the row type returned by `SourceAdapter.resolve_by_ids`.
+    """
+
+    ctx: Any
+    type: str
+    ids: list[str | int]
+    select: list[str]
+
+
+@dataclass(slots=True)
+class ConnectionRequest:
+    ctx: Any
+    procedure: str
+    args: dict[str, Any] | None
+    select: list[str]
+
+
+class SourceAdapter(ABC):
+    """Pluggable storage backend.
+
+    Implementations resolve entities for `byId` and lists. They also expose a
+    registry of DataViews so the executor can follow relations.
+    """
+
+    @abstractmethod
+    async def resolve_by_ids(
+        self, request: ByIdRequest[EntityT]
+    ) -> list[EntityT | None]: ...
+
+    @abstractmethod
+    async def resolve_connection(self, request: ConnectionRequest) -> FateConnectionResult: ...
+
+    @abstractmethod
+    def view_for(self, type_name: str) -> DataView[Any] | None: ...
+
+    @abstractmethod
+    def has_procedure(self, procedure: str) -> bool: ...
+
+
+FetchAllFn = Callable[[Any, str], Awaitable[Iterable[dict[str, Any]]]]
+
+
+class DictSourceAdapter(SourceAdapter):
+    """In-memory adapter: each entity type is stored as `list[dict]`.
+
+    Useful for tests and examples. Production code should ship its own adapter
+    backed by SQL / a real ORM.
+    """
+
+    def __init__(
+        self,
+        *,
+        views: dict[str, type[DataView[Any]] | DataView[Any]],
+        data: dict[str, list[dict[str, Any]]],
+        roots: dict[str, type[DataView[Any]] | DataView[Any] | ListField] | None = None,
+    ) -> None:
+        self._views: dict[str, DataView[Any]] = {
+            name: as_view(v) for name, v in views.items()
+        }
+        self._data = data
+        self._roots: dict[str, DataView[Any] | ListField] = {
+            name: (root if isinstance(root, ListField) else as_view(root))
+            for name, root in (roots or {}).items()
+        }
+
+    def view_for(self, type_name: str) -> DataView[Any] | None:
+        return self._views.get(type_name)
+
+    def has_procedure(self, procedure: str) -> bool:
+        return procedure in self._roots
+
+    async def resolve_by_ids(
+        self, request: ByIdRequest[EntityT]
+    ) -> list[EntityT | None]:
+        rows = self._data.get(request.type, [])
+        index: dict[str, dict[str, Any]] = {str(row["id"]): row for row in rows if "id" in row}
+        results: list[EntityT | None] = []
+        view = self._views.get(request.type)
+        for raw_id in request.ids:
+            row = index.get(str(raw_id))
+            if row is None:
+                results.append(None)
+                continue
+            if view is None:
+                results.append(cast(EntityT, row))
+                continue
+            materialized = await _materialize(row, view, request.select, request.ctx, self)
+            results.append(cast(EntityT, materialized))
+        return results
+
+    async def resolve_connection(self, request: ConnectionRequest) -> FateConnectionResult:
+        root = self._roots.get(request.procedure)
+        if root is None:
+            raise FateRequestError("NOT_FOUND", f"No list registered for '{request.procedure}'.")
+        maybe_view = root.view if isinstance(root, ListField) else root
+        if maybe_view is None:
+            raise FateRequestError(
+                "BAD_REQUEST",
+                f"List '{request.procedure}' is missing a view; "
+                "did you forget to pass one to list_field()?",
+            )
+        view: DataView = maybe_view
+        type_name = view.type_name
+        rows = list(self._data.get(type_name, []))
+
+        # naive ordering: stable order by id ascending
+        rows.sort(key=lambda r: str(r.get("id", "")))
+
+        node_select = subselect(request.select, "items.node")
+
+        async def query(params: Any) -> list[dict[str, Any]]:
+            cursor = params.cursor
+            if cursor is not None:
+                index = next(
+                    (i for i, r in enumerate(rows) if str(r.get("id")) == str(cursor)),
+                    -1,
+                )
+                if index < 0:
+                    return []
+                if params.direction == "forward":
+                    start = index + (params.skip or 0)
+                    return rows[start : start + params.take]
+                else:
+                    end = index - (params.skip or 0) + 1
+                    start = max(0, end - params.take)
+                    return rows[start:end]
+            if params.direction == "backward":
+                return rows[-params.take :]
+            return rows[: params.take]
+
+        async def map_items(ctx: Any, _input: dict[str, Any], items: list[dict[str, Any]]) -> list[Any]:
+            return [await _materialize(item, view, node_select, ctx, self) for item in items]
+
+        return await resolve_connection(
+            ctx=request.ctx,
+            input={"args": request.args},
+            query=query,
+            map_items=map_items,
+            default_size=root.default_size if isinstance(root, ListField) and root.default_size else 20,
+        )
+
+
+async def _materialize(
+    item: dict[str, Any],
+    view: DataView,
+    select: Iterable[str],
+    ctx: Any,
+    adapter: SourceAdapter,
+) -> dict[str, Any]:
+    """Materialize a row through a DataView, projecting only the selected fields."""
+
+    from .data_view import ComputedField, ListField, ResolverField  # local import to avoid cycles
+
+    select_list = list(select)
+    out: dict[str, Any] = {}
+    for name, spec in view.fields.items():
+        if not has_path(select_list, name):
+            continue
+        if spec is True:
+            if name in item:
+                out[name] = item[name]
+            continue
+        if isinstance(spec, DataView):
+            value = item.get(name)
+            if value is None:
+                out[name] = None
+                continue
+            sub_select = subselect(select_list, name)
+            if isinstance(value, dict):
+                out[name] = await _materialize(value, spec, sub_select, ctx, adapter)
+            elif isinstance(value, (str, int)):
+                resolved = await adapter.resolve_by_ids(
+                    ByIdRequest(ctx=ctx, type=spec.type_name, ids=[value], select=sub_select)
+                )
+                out[name] = resolved[0]
+            else:
+                out[name] = value
+            continue
+        if isinstance(spec, ListField):
+            if spec.view is None:
+                continue
+            list_view = spec.view
+            sub_select = subselect(select_list, name)
+            value = item.get(name)
+            if isinstance(value, list):
+                items_out: list[dict[str, Any]] = []
+                for idx, child in enumerate(value):
+                    if isinstance(child, dict):
+                        child_dict = cast(dict[str, Any], child)
+                        cursor = str(child_dict.get("id", idx))
+                        node = await _materialize(
+                            child_dict,
+                            list_view,
+                            subselect(sub_select, "items.node"),
+                            ctx,
+                            adapter,
+                        )
+                    else:
+                        cursor = str(idx)
+                        node = child
+                    items_out.append({"cursor": cursor, "node": node})
+                out[name] = {
+                    "items": items_out,
+                    "pagination": {"hasNext": False, "hasPrevious": False},
+                }
+            else:
+                out[name] = {"items": [], "pagination": {"hasNext": False, "hasPrevious": False}}
+            continue
+        if isinstance(spec, ResolverField):
+            value = spec.resolve(item, ctx, None)
+            if hasattr(value, "__await__"):
+                value = await value  # type: ignore[assignment]
+            out[name] = value
+            continue
+        if isinstance(spec, ComputedField):
+            deps = {k: item.get(k) for k in (spec.select or {})}
+            out[name] = spec.resolve(item, deps, ctx, None)
+            continue
+    return out
+
+
+__all__ = [
+    "ByIdRequest",
+    "ConnectionRequest",
+    "DictSourceAdapter",
+    "SourceAdapter",
+]

--- a/packages/py-fate/src/py_fate/sse.py
+++ b/packages/py-fate/src/py_fate/sse.py
@@ -1,0 +1,49 @@
+"""Server-Sent Events frame formatting.
+
+Mirrors the `sse` and `sseComment` helpers in `packages/fate/src/server/http.ts`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def sse_frame(message: Any, *, event_id: str | None = None) -> bytes:
+    """Format an SSE event frame.
+
+    `message` must be JSON-serializable. The event field comes from the message's
+    `kind`, which must be one of "next", "connection", or "error".
+    """
+
+    kind: str
+    payload: Any
+    if hasattr(message, "model_dump"):
+        payload = message.model_dump(exclude_none=True)
+        kind = payload.get("kind", "message")
+    elif isinstance(message, dict):
+        payload = message
+        kind = message.get("kind", "message")
+    else:
+        raise TypeError("sse_frame expects a dict or a pydantic model")
+
+    lines: list[str] = []
+    if event_id:
+        lines.append(f"id: {event_id}")
+    lines.append(f"event: {kind}")
+    lines.append(f"data: {json.dumps(payload, separators=(',', ':'))}")
+    return ("\n".join(lines) + "\n\n").encode("utf-8")
+
+
+def sse_comment(message: str) -> bytes:
+    return f": {message}\n\n".encode()
+
+
+SSE_HEADERS: dict[str, str] = {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    "connection": "keep-alive",
+}
+
+
+__all__ = ["SSE_HEADERS", "sse_comment", "sse_frame"]

--- a/packages/py-fate/tests/conftest.py
+++ b/packages/py-fate/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+pytest_plugins = ["pytest_asyncio"]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/packages/py-fate/tests/test_asgi.py
+++ b/packages/py-fate/tests/test_asgi.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+import httpx
+import pytest
+
+from py_fate.data_view import DataView, Scalar
+from py_fate.integrations.asgi import fate_asgi_app
+from py_fate.server import create_fate_server
+from py_fate.source import DictSourceAdapter
+
+
+def _build_app() -> Any:
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView},
+        data={"User": [{"id": "u1", "name": "Alice"}]},
+    )
+    server = create_fate_server(roots={}, sources=adapter)
+    return fate_asgi_app(server, prefix="/fate")
+
+
+@pytest.mark.asyncio
+async def test_asgi_byid_round_trip() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/fate",
+            json={
+                "version": 1,
+                "operations": [
+                    {
+                        "id": "1",
+                        "kind": "byId",
+                        "type": "User",
+                        "ids": ["u1"],
+                        "select": ["id", "name"],
+                    }
+                ],
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 1
+    assert body["results"][0]["data"] == [{"id": "u1", "name": "Alice"}]
+
+
+@pytest.mark.asyncio
+async def test_asgi_unknown_route() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/fate/bogus")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_asgi_method_not_allowed() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/fate")
+    assert response.status_code == 405

--- a/packages/py-fate/tests/test_connection.py
+++ b/packages/py-fate/tests/test_connection.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+import pytest
+
+from py_fate.connection import QueryParams, resolve_connection
+from py_fate.protocol import FateRequestError
+
+
+def make_rows(n: int) -> list[dict[str, Any]]:
+    return [{"id": str(i), "value": i} for i in range(1, n + 1)]
+
+
+async def _query(rows: list[dict[str, Any]], params: QueryParams) -> list[dict[str, Any]]:
+    cursor = params.cursor
+    if cursor is not None:
+        idx = next((i for i, r in enumerate(rows) if r["id"] == cursor), -1)
+        if idx < 0:
+            return []
+        if params.direction == "forward":
+            start = idx + (params.skip or 0)
+            return rows[start : start + params.take]
+        end = idx - (params.skip or 0) + 1
+        start = max(0, end - params.take)
+        return rows[start:end]
+    if params.direction == "backward":
+        return rows[-params.take :]
+    return rows[: params.take]
+
+
+async def test_forward_first_page_has_next() -> None:
+    rows = make_rows(50)
+
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return await _query(rows, p)
+
+    result = await resolve_connection(ctx=None, input={"args": {"first": 10}}, query=q)
+    assert len(result.items) == 10
+    assert result.pagination.hasNext is True
+    assert result.pagination.hasPrevious is False
+    assert result.pagination.nextCursor == "10"
+
+
+async def test_forward_with_after_cursor() -> None:
+    rows = make_rows(50)
+
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return await _query(rows, p)
+
+    result = await resolve_connection(
+        ctx=None, input={"args": {"first": 10, "after": "10"}}, query=q
+    )
+    assert [item.node["id"] for item in result.items] == [str(i) for i in range(11, 21)]
+    assert result.pagination.hasPrevious is True
+    assert result.pagination.hasNext is True
+
+
+async def test_backward_last_page() -> None:
+    rows = make_rows(50)
+
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return await _query(rows, p)
+
+    result = await resolve_connection(ctx=None, input={"args": {"last": 5}}, query=q)
+    assert [item.node["id"] for item in result.items] == ["46", "47", "48", "49", "50"]
+    assert result.pagination.hasPrevious is True
+    assert result.pagination.hasNext is False
+
+
+async def test_default_page_size() -> None:
+    rows = make_rows(50)
+
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return await _query(rows, p)
+
+    result = await resolve_connection(ctx=None, input={"args": None}, query=q)
+    assert len(result.items) == 20
+
+
+async def test_rejects_first_and_last() -> None:
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return []
+
+    with pytest.raises(FateRequestError) as exc:
+        await resolve_connection(ctx=None, input={"args": {"first": 5, "last": 5}}, query=q)
+    assert exc.value.code == "VALIDATION_ERROR"
+
+
+async def test_rejects_after_and_before() -> None:
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return []
+
+    with pytest.raises(FateRequestError) as exc:
+        await resolve_connection(
+            ctx=None, input={"args": {"after": "1", "before": "9"}}, query=q
+        )
+    assert exc.value.code == "VALIDATION_ERROR"
+
+
+async def test_empty_result() -> None:
+    async def q(p: QueryParams) -> list[dict[str, Any]]:
+        return []
+
+    result = await resolve_connection(ctx=None, input={"args": {"first": 10}}, query=q)
+    assert result.items == []
+    assert result.pagination.hasNext is False
+    assert result.pagination.hasPrevious is False

--- a/packages/py-fate/tests/test_data_view_class.py
+++ b/packages/py-fate/tests/test_data_view_class.py
@@ -1,0 +1,264 @@
+"""Tests for the class-based declarative DataView form."""
+
+from __future__ import annotations
+
+import pytest
+
+from py_fate import (
+    ByIdRequest,
+    ComputedField,
+    DataView,
+    DictSourceAdapter,
+    ListField,
+    ResolverField,
+    Scalar,
+    as_view,
+    computed,
+    list_field,
+    resolver,
+)
+
+
+def test_type_name_inferred_from_class_name():
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    assert UserView.type_name == "User"
+    assert set(UserView.fields.keys()) == {"id", "name"}
+    assert UserView.fields["id"] is True
+    assert UserView.fields["name"] is True
+
+
+def test_type_name_override():
+    class UserView(DataView, type_name="Account"):
+        id: Scalar
+
+    assert UserView.type_name == "Account"
+
+
+def test_non_view_suffix_class_name():
+    class Comment(DataView):
+        id: Scalar
+
+    assert Comment.type_name == "Comment"
+
+
+def test_plain_python_annotations_treated_as_scalars():
+    class UserView(DataView):
+        id: int
+        name: str
+        active: bool
+
+    assert UserView.fields == {"id": True, "name": True, "active": True}
+
+
+def test_nested_relation_via_class_annotation():
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        title: Scalar
+        author: UserView
+
+    author_spec = PostView.fields["author"]
+    assert isinstance(author_spec, DataView)
+    assert author_spec.type_name == "User"
+    assert set(author_spec.fields.keys()) == {"id", "name"}
+
+
+def test_list_relation_from_list_generic():
+    class CommentView(DataView):
+        id: Scalar
+        body: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        comments: list[CommentView]
+
+    spec = PostView.fields["comments"]
+    assert isinstance(spec, ListField)
+    assert spec.view is not None
+    assert spec.view.type_name == "Comment"
+
+
+def test_list_field_default_with_config_and_annotation_inferred_view():
+    class CommentView(DataView):
+        id: Scalar
+
+    class PostView(DataView):
+        comments: list[CommentView] = list_field(order_by=[("createdAt", "asc")])
+
+    spec = PostView.fields["comments"]
+    assert isinstance(spec, ListField)
+    assert spec.view is not None
+    assert spec.view.type_name == "Comment"
+    assert spec.order_by == [("createdAt", "asc")]
+
+
+def test_computed_decorator():
+    class PostView(DataView):
+        id: Scalar
+
+        @computed(select={"authorId": True})
+        def is_owner(item, deps, ctx):
+            return deps["authorId"] == "u1"
+
+    spec = PostView.fields["is_owner"]
+    assert isinstance(spec, ComputedField)
+    assert spec.select == {"authorId": True}
+    assert spec.resolve({"authorId": "u1"}, {"authorId": "u1"}, None) is True
+
+
+def test_resolver_decorator_bare():
+    class PostView(DataView):
+        id: Scalar
+
+        @resolver
+        def like_count(item, ctx):
+            return 7
+
+    spec = PostView.fields["like_count"]
+    assert isinstance(spec, ResolverField)
+    assert spec.resolve({}, None) == 7
+
+
+def test_resolver_decorator_with_args():
+    class PostView(DataView):
+        id: Scalar
+
+        @resolver(select={"id": True})
+        def like_count(item, ctx):
+            return 9
+
+    spec = PostView.fields["like_count"]
+    assert isinstance(spec, ResolverField)
+    assert spec.select == {"id": True}
+
+
+def test_as_view_is_idempotent():
+    class UserView(DataView):
+        id: Scalar
+
+    v1 = as_view(UserView)
+    v2 = as_view(UserView)
+    assert v1 is v2  # cached singleton
+    assert as_view(v1) is v1
+
+
+def test_dict_source_adapter_accepts_class_form_views():
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        title: Scalar
+        author: UserView
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView, "Post": PostView},
+        data={
+            "User": [{"id": "u1", "name": "Alice"}],
+            "Post": [{"id": "p1", "title": "Hello", "author": "u1"}],
+        },
+        roots={"posts": list_field(PostView)},
+    )
+
+    user_view = adapter.view_for("User")
+    assert user_view is not None
+    assert user_view.type_name == "User"
+    assert adapter.has_procedure("posts")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_ids_through_class_based_view():
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        title: Scalar
+        author: UserView
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView, "Post": PostView},
+        data={
+            "User": [{"id": "u1", "name": "Alice"}],
+            "Post": [{"id": "p1", "title": "Hello", "author": "u1"}],
+        },
+    )
+
+    results = await adapter.resolve_by_ids(
+        ByIdRequest(
+            ctx=None,
+            type="Post",
+            ids=["p1"],
+            select=["id", "title", "author.id", "author.name"],
+        )
+    )
+    assert results == [
+        {
+            "id": "p1",
+            "title": "Hello",
+            "author": {"id": "u1", "name": "Alice"},
+        }
+    ]
+
+
+def test_direct_construction_raises():
+    import pytest as _pytest
+
+    with _pytest.raises(TypeError, match="not directly constructible"):
+        DataView("User", {"id": True})  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_by_id_classmethod_returns_typed_entities():
+    from typing import TypedDict
+
+    class UserEntity(TypedDict):
+        id: str
+        name: str
+
+    class UserView(DataView[UserEntity]):
+        id: Scalar
+        name: Scalar
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView},
+        data={"User": [{"id": "u1", "name": "Alice"}]},
+    )
+
+    # The annotation here is a static-type assertion: if `EntityT` does not flow
+    # through `DataView[UserEntity].by_id(...)`, ty/pyright will reject this.
+    results: list[UserEntity | None] = await UserView.by_id(
+        adapter, None, ["u1"], select=["id", "name"]
+    )
+    assert results == [{"id": "u1", "name": "Alice"}]
+
+    one: UserEntity | None = await UserView.by_id_one(
+        adapter, None, "u1", select=["id", "name"]
+    )
+    assert one == {"id": "u1", "name": "Alice"}
+
+
+@pytest.mark.asyncio
+async def test_by_id_one_classmethod():
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView},
+        data={"User": [{"id": "u1", "name": "Alice"}]},
+    )
+
+    one = await UserView.by_id_one(adapter, None, "u1", select=["id", "name"])
+    assert one == {"id": "u1", "name": "Alice"}
+
+    missing = await UserView.by_id_one(adapter, None, "zzz", select=["id"])
+    assert missing is None

--- a/packages/py-fate/tests/test_executor.py
+++ b/packages/py-fate/tests/test_executor.py
@@ -1,0 +1,181 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+from py_fate.data_view import DataView, Scalar, list_field
+from py_fate.executor import (
+    MutationDefinition,
+    QueryDefinition,
+    ServerRegistry,
+    execute_operation,
+)
+from py_fate.protocol import FateOperation, FateOperationErr, FateOperationOk
+from py_fate.source import DictSourceAdapter
+
+
+def _registry() -> ServerRegistry:
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+        secret: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        title: Scalar
+        author: UserView
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView, "Post": PostView},
+        data={
+            "User": [
+                {"id": "u1", "name": "Alice", "secret": "shh"},
+                {"id": "u2", "name": "Bob", "secret": "ssh"},
+            ],
+            "Post": [
+                {"id": "p1", "title": "Hello", "author": "u1"},
+                {"id": "p2", "title": "World", "author": "u2"},
+            ],
+        },
+        roots={"posts": list_field(PostView)},
+    )
+
+    class CreatePostInput(BaseModel):
+        title: str
+
+    async def create_post(*, ctx: Any, input: CreatePostInput, select: list[str]) -> dict[str, Any]:
+        return {"id": "new", "title": input.title}
+
+    async def viewer(*, ctx: Any, input: dict[str, Any], select: list[str]) -> dict[str, Any]:
+        return {"id": "u1", "name": "Alice"}
+
+    return ServerRegistry(
+        queries={"viewer": QueryDefinition(resolve=viewer)},
+        mutations={
+            "createPost": MutationDefinition(
+                resolve=create_post, type="Post", input=CreatePostInput
+            )
+        },
+        lists={},
+        roots={"posts": list_field(PostView)},
+        sources=adapter,
+    )
+
+
+async def test_byid_filters_unselected_fields() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1",
+        kind="byId",
+        type="User",
+        ids=["u1"],
+        select=["id", "name"],
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    assert result.data == [{"id": "u1", "name": "Alice"}]
+
+
+async def test_byid_resolves_relation() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1",
+        kind="byId",
+        type="Post",
+        ids=["p1"],
+        select=["id", "title", "author.id", "author.name"],
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    assert result.data == [
+        {"id": "p1", "title": "Hello", "author": {"id": "u1", "name": "Alice"}}
+    ]
+
+
+async def test_byid_returns_null_for_missing() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1", kind="byId", type="User", ids=["zzz"], select=["id"]
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    assert result.data == [None]
+
+
+async def test_byid_unknown_type_returns_error_envelope() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1", kind="byId", type="Unknown", ids=["x"], select=["id"]
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationErr)
+    assert result.error.code == "NOT_FOUND"
+
+
+async def test_list_returns_connection() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1",
+        kind="list",
+        name="posts",
+        select=["items.node.id", "items.node.title", "pagination.hasNext"],
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    items = result.data.items
+    assert [it.node["id"] for it in items] == ["p1", "p2"]
+
+
+async def test_query_dispatch() -> None:
+    reg = _registry()
+    op = FateOperation(id="1", kind="query", name="viewer", select=["id", "name"])
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    assert result.data == {"id": "u1", "name": "Alice"}
+
+
+async def test_query_not_found() -> None:
+    reg = _registry()
+    op = FateOperation(id="1", kind="query", name="missing", select=[])
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationErr)
+    assert result.error.code == "NOT_FOUND"
+
+
+async def test_mutation_validates_input() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1",
+        kind="mutation",
+        name="createPost",
+        select=["id", "title"],
+        input={"wrong": "field"},
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationErr)
+    assert result.error.code == "VALIDATION_ERROR"
+
+
+async def test_mutation_success() -> None:
+    reg = _registry()
+    op = FateOperation(
+        id="1",
+        kind="mutation",
+        name="createPost",
+        select=["id", "title"],
+        input={"title": "Brand new"},
+    )
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationOk)
+    assert result.data == {"id": "new", "title": "Brand new"}
+
+
+async def test_internal_error_is_sanitized() -> None:
+    async def bad(*, ctx: Any, input: Any, select: list[str]) -> Any:
+        raise ValueError("super secret crash")
+
+    reg = ServerRegistry(queries={"crash": QueryDefinition(resolve=bad)})
+    op = FateOperation(id="1", kind="query", name="crash", select=[])
+    result = await execute_operation(op, ctx=None, registry=reg)
+    assert isinstance(result, FateOperationErr)
+    assert result.error.code == "INTERNAL_ERROR"
+    assert "secret" not in result.error.message

--- a/packages/py-fate/tests/test_fastapi.py
+++ b/packages/py-fate/tests/test_fastapi.py
@@ -1,0 +1,158 @@
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from py_fate.data_view import DataView, Scalar, list_field
+from py_fate.executor import MutationDefinition, QueryDefinition
+from py_fate.integrations.fastapi import fate_router
+from py_fate.server import create_fate_server
+from py_fate.source import DictSourceAdapter
+
+
+def _build_app() -> FastAPI:
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    class PostView(DataView):
+        id: Scalar
+        title: Scalar
+        author: UserView
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView, "Post": PostView},
+        data={
+            "User": [{"id": "u1", "name": "Alice"}],
+            "Post": [
+                {"id": "p1", "title": "Hello", "author": "u1"},
+                {"id": "p2", "title": "World", "author": "u1"},
+            ],
+        },
+        roots={"posts": list_field(PostView)},
+    )
+
+    class CreatePost(BaseModel):
+        title: str
+
+    async def create_post(*, ctx: Any, input: CreatePost, select: list[str]) -> dict[str, Any]:
+        return {"id": "p3", "title": input.title}
+
+    async def viewer(*, ctx: Any, input: dict[str, Any], select: list[str]) -> dict[str, Any]:
+        return {"id": "u1", "name": "Alice"}
+
+    server = create_fate_server(
+        queries={"viewer": QueryDefinition(resolve=viewer)},
+        mutations={
+            "createPost": MutationDefinition(
+                resolve=create_post, type="Post", input=CreatePost
+            )
+        },
+        roots={"posts": list_field(PostView)},
+        sources=adapter,
+    )
+
+    app = FastAPI()
+    app.include_router(fate_router(server), prefix="/fate")
+    return app
+
+
+@pytest.mark.asyncio
+async def test_fastapi_batched_operations() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/fate",
+            json={
+                "version": 1,
+                "operations": [
+                    {
+                        "id": "1",
+                        "kind": "byId",
+                        "type": "Post",
+                        "ids": ["p1"],
+                        "select": ["id", "title", "author.id", "author.name"],
+                    },
+                    {
+                        "id": "2",
+                        "kind": "list",
+                        "name": "posts",
+                        "select": ["items.node.id", "items.node.title", "pagination.hasNext"],
+                    },
+                    {
+                        "id": "3",
+                        "kind": "query",
+                        "name": "viewer",
+                        "select": ["id", "name"],
+                    },
+                    {
+                        "id": "4",
+                        "kind": "mutation",
+                        "name": "createPost",
+                        "select": ["id", "title"],
+                        "input": {"title": "New!"},
+                    },
+                ],
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 1
+    results_by_id = {r["id"]: r for r in body["results"]}
+    assert results_by_id["1"]["ok"] is True
+    assert results_by_id["1"]["data"] == [
+        {"id": "p1", "title": "Hello", "author": {"id": "u1", "name": "Alice"}}
+    ]
+    assert results_by_id["2"]["ok"] is True
+    posts = results_by_id["2"]["data"]
+    assert [item["node"]["id"] for item in posts["items"]] == ["p1", "p2"]
+    assert posts["pagination"]["hasNext"] is False
+    assert results_by_id["3"]["ok"] is True
+    assert results_by_id["4"]["ok"] is True
+    assert results_by_id["4"]["data"] == {"id": "p3", "title": "New!"}
+
+
+@pytest.mark.asyncio
+async def test_fastapi_mutation_validation_error() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/fate",
+            json={
+                "version": 1,
+                "operations": [
+                    {
+                        "id": "x",
+                        "kind": "mutation",
+                        "name": "createPost",
+                        "select": ["id"],
+                        "input": {"missing": "fields"},
+                    }
+                ],
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["results"][0]["ok"] is False
+    assert body["results"][0]["error"]["code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_fastapi_content_type_header() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/fate",
+            json={
+                "version": 1,
+                "operations": [
+                    {"id": "1", "kind": "query", "name": "viewer", "select": ["id"]}
+                ],
+            },
+        )
+    assert "application/json" in response.headers["content-type"]

--- a/packages/py-fate/tests/test_http_core.py
+++ b/packages/py-fate/tests/test_http_core.py
@@ -1,0 +1,101 @@
+import json
+from typing import Any
+
+from py_fate.data_view import DataView, Scalar
+from py_fate.executor import QueryDefinition
+from py_fate.http import FateHTTPRequest
+from py_fate.server import create_fate_server
+from py_fate.source import DictSourceAdapter
+
+
+def _make_request(method: str, url: str, body: bytes = b"") -> FateHTTPRequest:
+    async def read_body() -> bytes:
+        return body
+
+    return FateHTTPRequest(
+        method=method, url=url, headers={"content-type": "application/json"}, read_body=read_body
+    )
+
+
+def _server() -> Any:
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView},
+        data={"User": [{"id": "u1", "name": "Alice"}]},
+        roots={},
+    )
+
+    async def viewer(*, ctx: Any, input: Any, select: list[str]) -> dict[str, Any]:
+        return {"id": "u1", "name": "Alice"}
+
+    return create_fate_server(
+        queries={"viewer": QueryDefinition(resolve=viewer)},
+        roots={},
+        sources=adapter,
+    )
+
+
+async def test_handle_request_byid() -> None:
+    server = _server()
+    payload = {
+        "version": 1,
+        "operations": [
+            {"id": "1", "kind": "byId", "type": "User", "ids": ["u1"], "select": ["id", "name"]}
+        ],
+    }
+    req = _make_request("POST", "/fate", json.dumps(payload).encode("utf-8"))
+    res = await server.handle_request(req)
+    assert res.status == 200
+    body = json.loads(res.body)
+    assert body["version"] == 1
+    assert body["results"][0]["ok"] is True
+    assert body["results"][0]["data"] == [{"id": "u1", "name": "Alice"}]
+    assert res.headers["content-type"] == "application/json; charset=utf-8"
+
+
+async def test_handle_request_invalid_json_returns_envelope() -> None:
+    server = _server()
+    req = _make_request("POST", "/fate", b"{not json")
+    res = await server.handle_request(req)
+    assert res.status == 400
+    body = json.loads(res.body)
+    assert body["results"][0]["id"] == "request"
+    assert body["results"][0]["ok"] is False
+    assert body["results"][0]["error"]["code"] == "BAD_REQUEST"
+
+
+async def test_handle_request_invalid_protocol_request() -> None:
+    server = _server()
+    req = _make_request("POST", "/fate", json.dumps({"version": 2}).encode("utf-8"))
+    res = await server.handle_request(req)
+    assert res.status == 400
+    body = json.loads(res.body)
+    assert body["results"][0]["error"]["code"] == "BAD_REQUEST"
+
+
+async def test_handle_request_batches_multiple_operations() -> None:
+    server = _server()
+    payload = {
+        "version": 1,
+        "operations": [
+            {"id": "a", "kind": "query", "name": "viewer", "select": ["id"]},
+            {"id": "b", "kind": "byId", "type": "User", "ids": ["u1"], "select": ["id"]},
+        ],
+    }
+    req = _make_request("POST", "/fate", json.dumps(payload).encode("utf-8"))
+    res = await server.handle_request(req)
+    body = json.loads(res.body)
+    ids = [r["id"] for r in body["results"]]
+    assert ids == ["a", "b"]
+
+
+async def test_handle_live_disabled() -> None:
+    server = _server()
+    req = _make_request("GET", "/fate/live?connectionId=x")
+    res = await server.handle_live_get(req)
+    body = json.loads(res.body)
+    assert res.status == 404
+    assert body["results"][0]["error"]["code"] == "NOT_FOUND"

--- a/packages/py-fate/tests/test_live.py
+++ b/packages/py-fate/tests/test_live.py
@@ -1,0 +1,160 @@
+import asyncio
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from py_fate.data_view import DataView, Scalar
+from py_fate.integrations.fastapi import fate_router
+from py_fate.live.memory import create_live_event_bus
+from py_fate.server import create_fate_server
+from py_fate.source import DictSourceAdapter
+
+
+def _parse_sse(buffer: bytes) -> list[dict[str, str]]:
+    """Parse SSE buffer into events. Each event is {id?, event?, data?}."""
+
+    events: list[dict[str, str]] = []
+    text = buffer.decode("utf-8")
+    for chunk in text.split("\n\n"):
+        chunk = chunk.strip("\n")
+        if not chunk or chunk.startswith(":"):
+            continue
+        event: dict[str, str] = {}
+        for line in chunk.splitlines():
+            if ":" in line:
+                name, _, value = line.partition(":")
+                event[name.strip()] = value.strip()
+        if event:
+            events.append(event)
+    return events
+
+
+def _build_app():  # type: ignore[no-untyped-def]
+    class UserView(DataView):
+        id: Scalar
+        name: Scalar
+
+    adapter = DictSourceAdapter(
+        views={"User": UserView},
+        data={"User": [{"id": "u1", "name": "Alice"}, {"id": "u2", "name": "Bob"}]},
+    )
+    bus = create_live_event_bus()
+    server = create_fate_server(roots={}, sources=adapter, live=bus)
+    app = FastAPI()
+    app.include_router(fate_router(server), prefix="/fate")
+    return app, bus, server
+
+
+@pytest.mark.asyncio
+async def test_live_post_without_get_is_not_found() -> None:
+    app, _bus, _server = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/fate/live",
+            json={
+                "version": 1,
+                "connectionId": "missing",
+                "operations": [],
+            },
+        )
+    assert response.status_code == 404
+    body = response.json()
+    assert body["results"][0]["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_live_entity_subscribe_emits_event() -> None:
+    app, bus, server = _build_app()
+
+    # Manually register a live connection on the server (skip the SSE GET).
+    from py_fate.live.connection import LiveConnection
+
+    outbox: asyncio.Queue[bytes | None] = asyncio.Queue()
+    conn = LiveConnection(connection_id="c1", outbox=outbox)
+    server._connections.register(conn)  # type: ignore[attr-defined]
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        sub_resp = await client.post(
+            "/fate/live",
+            json={
+                "version": 1,
+                "connectionId": "c1",
+                "operations": [
+                    {
+                        "id": "s1",
+                        "kind": "subscribe",
+                        "type": "User",
+                        "entityId": "u1",
+                        "select": ["id", "name"],
+                    }
+                ],
+            },
+        )
+    assert sub_resp.status_code == 200
+    body = sub_resp.json()
+    assert body["results"][0]["ok"] is True
+
+    # Emit an event; the bus should fan it out to the subscription task,
+    # which resolves byId and pushes an SSE frame onto the outbox.
+    await bus.emit("User", "u1", changed=["name"], event_id="evt-1")
+
+    # Wait for the frame
+    frame = await asyncio.wait_for(outbox.get(), timeout=2.0)
+    assert frame is not None
+    events = _parse_sse(frame)
+    assert events[0]["event"] == "next"
+    payload = json.loads(events[0]["data"])
+    assert payload["kind"] == "next"
+    assert payload["event"]["data"] == {"id": "u1", "name": "Alice"}
+
+    # Clean up
+    await server._connections.remove("c1")  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_live_unsubscribe_stops_events() -> None:
+    app, bus, server = _build_app()
+    from py_fate.live.connection import LiveConnection
+
+    outbox: asyncio.Queue[bytes | None] = asyncio.Queue()
+    conn = LiveConnection(connection_id="c2", outbox=outbox)
+    server._connections.register(conn)  # type: ignore[attr-defined]
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/fate/live",
+            json={
+                "version": 1,
+                "connectionId": "c2",
+                "operations": [
+                    {
+                        "id": "s1",
+                        "kind": "subscribe",
+                        "type": "User",
+                        "entityId": "u1",
+                        "select": ["id"],
+                    }
+                ],
+            },
+        )
+        await client.post(
+            "/fate/live",
+            json={
+                "version": 1,
+                "connectionId": "c2",
+                "operations": [{"id": "s1", "kind": "unsubscribe"}],
+            },
+        )
+
+    # Give the cancellation a moment to settle
+    await asyncio.sleep(0.05)
+    await bus.emit("User", "u1", event_id="evt-2")
+    await asyncio.sleep(0.05)
+    assert outbox.empty()
+
+    await server._connections.remove("c2")  # type: ignore[attr-defined]

--- a/packages/py-fate/tests/test_protocol.py
+++ b/packages/py-fate/tests/test_protocol.py
@@ -1,0 +1,102 @@
+import pytest
+from pydantic import ValidationError
+
+from py_fate.protocol import (
+    FateLiveControlRequest,
+    FateOperation,
+    FateProtocolRequest,
+    FateRequestError,
+    error_code_from_status,
+    status_from_error_code,
+    to_protocol_error,
+)
+
+
+def test_status_round_trip() -> None:
+    for code in (
+        "BAD_REQUEST",
+        "VALIDATION_ERROR",
+        "UNAUTHORIZED",
+        "FORBIDDEN",
+        "NOT_FOUND",
+        "INTERNAL_ERROR",
+    ):
+        status = status_from_error_code(code)  # type: ignore[arg-type]
+        # VALIDATION_ERROR is also 400 — error_code_from_status returns BAD_REQUEST for 400.
+        round_tripped = error_code_from_status(status)
+        if code == "VALIDATION_ERROR":
+            assert round_tripped == "BAD_REQUEST"
+        else:
+            assert round_tripped == code
+
+
+def test_status_mapping() -> None:
+    assert status_from_error_code("BAD_REQUEST") == 400
+    assert status_from_error_code("VALIDATION_ERROR") == 400
+    assert status_from_error_code("UNAUTHORIZED") == 401
+    assert status_from_error_code("FORBIDDEN") == 403
+    assert status_from_error_code("NOT_FOUND") == 404
+    assert status_from_error_code("INTERNAL_ERROR") == 500
+
+
+def test_to_protocol_error_preserves_fate_request_error() -> None:
+    err = FateRequestError("FORBIDDEN", "nope", issues=["one"], path="x")
+    p = to_protocol_error(err)
+    assert p.code == "FORBIDDEN"
+    assert p.message == "nope"
+    assert p.issues == ["one"]
+    assert p.path == "x"
+
+
+def test_to_protocol_error_sanitizes_unknown_exception() -> None:
+    p = to_protocol_error(RuntimeError("secret token leaked"))
+    assert p.code == "INTERNAL_ERROR"
+    assert p.message == "Internal server error."
+
+
+def test_protocol_request_parses_byid() -> None:
+    payload = {
+        "version": 1,
+        "operations": [
+            {
+                "id": "1",
+                "kind": "byId",
+                "type": "Post",
+                "ids": ["a", 2],
+                "select": ["id", "title"],
+            }
+        ],
+    }
+    req = FateProtocolRequest.model_validate(payload)
+    op = req.operations[0]
+    assert op.kind == "byId"
+    assert op.ids == ["a", 2]
+
+
+def test_protocol_request_rejects_invalid_version() -> None:
+    with pytest.raises(ValidationError):
+        FateProtocolRequest.model_validate({"version": 2, "operations": []})
+
+
+def test_live_control_subscribe_parses() -> None:
+    payload = {
+        "version": 1,
+        "connectionId": "abc",
+        "operations": [
+            {
+                "id": "s1",
+                "kind": "subscribe",
+                "type": "Post",
+                "entityId": "p-1",
+                "select": ["id", "title"],
+            }
+        ],
+    }
+    req = FateLiveControlRequest.model_validate(payload)
+    assert req.connectionId == "abc"
+    assert req.operations[0].kind == "subscribe"
+
+
+def test_operation_kind_invalid_rejected() -> None:
+    with pytest.raises(ValidationError):
+        FateOperation.model_validate({"id": "1", "kind": "bogus", "select": []})

--- a/packages/py-fate/tests/test_selection.py
+++ b/packages/py-fate/tests/test_selection.py
@@ -1,0 +1,56 @@
+from py_fate.selection import (
+    filter_by_paths,
+    has_path,
+    parse_paths,
+    paths_intersect,
+    subselect,
+    tree_to_paths,
+)
+
+
+def test_parse_paths_basic() -> None:
+    tree = parse_paths(["id", "title"])
+    assert tree == {"id": True, "title": True}
+
+
+def test_parse_paths_nested() -> None:
+    tree = parse_paths(["id", "author.id", "author.name"])
+    assert tree == {"id": True, "author": {"id": True, "name": True}}
+
+
+def test_tree_round_trip() -> None:
+    paths = ["id", "author.id", "author.name", "comments.items.node.id"]
+    tree = parse_paths(paths)
+    round_tripped = sorted(tree_to_paths(tree))
+    assert round_tripped == sorted(paths)
+
+
+def test_subselect_strips_prefix() -> None:
+    paths = ["id", "author.id", "author.name", "title"]
+    assert sorted(subselect(paths, "author")) == ["id", "name"]
+
+
+def test_has_path() -> None:
+    paths = ["id", "author.id"]
+    assert has_path(paths, "id")
+    assert has_path(paths, "author")
+    assert not has_path(paths, "title")
+
+
+def test_paths_intersect() -> None:
+    assert paths_intersect("a", "a")
+    assert paths_intersect("a.b", "a")
+    assert paths_intersect("a", "a.b")
+    assert not paths_intersect("a", "b")
+    assert not paths_intersect("ab", "a")
+
+
+def test_filter_by_paths_dict() -> None:
+    value = {"id": 1, "title": "t", "secret": "s", "author": {"id": 9, "password": "p"}}
+    filtered = filter_by_paths(value, ["id", "title", "author.id"])
+    assert filtered == {"id": 1, "title": "t", "author": {"id": 9}}
+
+
+def test_filter_by_paths_list_of_dicts() -> None:
+    value = [{"id": 1, "x": "a"}, {"id": 2, "x": "b"}]
+    assert filter_by_paths(value, ["id"]) == [{"id": 1}, {"id": 2}]

--- a/packages/py-fate/uv.lock
+++ b/packages/py-fate/uv.lock
@@ -1,0 +1,428 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-fate"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+asgi = [
+    { name = "starlette" },
+]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+    { name = "starlette" },
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.110" },
+    { name = "pydantic", specifier = ">=2.5" },
+    { name = "starlette", marker = "extra == 'asgi'", specifier = ">=0.36" },
+    { name = "typing-extensions", specifier = ">=4.12" },
+]
+provides-extras = ["fastapi", "asgi"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "fastapi", specifier = ">=0.110" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = ">=0.6" },
+    { name = "starlette", specifier = ">=0.36" },
+    { name = "ty", specifier = ">=0.0.1a14" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/3b/45be6b37d5060d6917bf7f1f234c00d360fc5f8b7486f8a96af640e25661/ty-0.0.38.tar.gz", hash = "sha256:fbc8d47f7630457669ab41e333dc093897fdb7ead1ffc94dcf8f30b5d39aa56d", size = 5681218, upload-time = "2026-05-20T00:15:32.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/43/ea9b4e57d6a266670dbe34858e92f6093ca054ad1b48f1c82580a72340fb/ty-0.0.38-py3-none-linux_armv6l.whl", hash = "sha256:3501dcf44ca03f813f9cb4fabfdf601adc0ac1337c411405b470530679e37a45", size = 11289326, upload-time = "2026-05-20T00:14:52.371Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ff/24e2f623a1c6b5f5ccf8bf82fccd937033c6a7dba57a4028c7f41270fa4a/ty-0.0.38-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b34b4094b76252c3e8c90762cdd5e8a9f1101534484745ff4b480f71eb38ac2e", size = 11063047, upload-time = "2026-05-20T00:14:42.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/41/4f0d910f0acbd20b358eda80a5cd6a8361d27ff5b8e87ab559d3f69f125e/ty-0.0.38-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c518ad33a877677365baab2e21d82cf59ffee789203a15a143f5179ee5a1d3f8", size = 10494436, upload-time = "2026-05-20T00:15:24.425Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d8/da06833422082aa98b169a391f9197e2d73865e96c90b6979ac886b890a2/ty-0.0.38-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9238494722303eccddc6a27eb647948b694eecd6b974910d13b9e6cd46bbeb6a", size = 11000992, upload-time = "2026-05-20T00:14:58.368Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f7/e1172197fb827e6410ca3eb0dc68ef2789f3c70683696f2a0ce5c90764fd/ty-0.0.38-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31d91d7336c5d51bf822ac0df512f300584ca4dcca041fc6a6d7df03a8ddbb31", size = 11058583, upload-time = "2026-05-20T00:15:11.314Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/61/7fbaf0c05981e006a8804287819c574dff90a6bf8e96efad7226be0700aa/ty-0.0.38-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65165879814993450710b9349791e4898c65e36b1e14eec554884c06a2f20ff1", size = 11531036, upload-time = "2026-05-20T00:15:14.62Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/47c0c64e401d50f925df3e52479d4e7626754b2a9e38201d142fdacd6252/ty-0.0.38-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d61868b8d1c4033bf8088191de953fed245c2f9e1bb9d2d53e5699170b0924c", size = 12129991, upload-time = "2026-05-20T00:14:39.475Z" },
+    { url = "https://files.pythonhosted.org/packages/90/99/2f452d02901bcd7f1b109cf5b848727ce37f372c3406143aa52d1305d40e/ty-0.0.38-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8f9a9175548c98dbff7707865738c07c2b1f8e07a09b8c68101baebb5dac59a4", size = 11756167, upload-time = "2026-05-20T00:15:27.526Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/c7e14d111c813e1a20b82e944f1c997c4631a2bb710eaa64fb6b26835e13/ty-0.0.38-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:375d3a964c6b4aea2e9237fdb5eb9ed03dc43088986a94209a28a4ea3b62001c", size = 11637099, upload-time = "2026-05-20T00:15:21.261Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/ab02659dd1ed62898db7db4d37f9937c80854dd45e95093fa0fe10328d82/ty-0.0.38-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:cdfd547782c45267aa0b52abad31bd406bf4768c264532ef9e2360cd3c6ce048", size = 11813583, upload-time = "2026-05-20T00:14:45.875Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/57/bd1b5ebf4e71a4295484afac0202df1740b0807762b86744b1bef4534984/ty-0.0.38-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:858bc675b75626470abe4e6c3b3934b853642b04f2ac4d7139fcefea3b48b213", size = 10975405, upload-time = "2026-05-20T00:15:30.354Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/55/0305c78711bbd23922cf291996a08ef9544f4179da98e9a75c14e608f379/ty-0.0.38-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:54be4f00432870da42cd74fe145a3362fd248e22d032c74bd807cb45bf068f94", size = 11097551, upload-time = "2026-05-20T00:14:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4f/7effe7f9a6ac9719eb7234172c01739c5f888bb47f9acc2ea8da1f4afed3/ty-0.0.38-py3-none-musllinux_1_2_i686.whl", hash = "sha256:494af66a76a86dbf16a3003d3b63b03484aa4c7489dfe11f3ee5413b98b22d60", size = 11214391, upload-time = "2026-05-20T00:15:18.094Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/d9fdfec3a74a6ad0209fa5e7113ae29d4f457d0651cfbb813b4c6563e0d4/ty-0.0.38-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3d92527c4be78a5ce6d32e8bb0aa2a6988d4076eddf1294e56fdaf06d1a98e7e", size = 11730871, upload-time = "2026-05-20T00:14:49.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4a/beefade12d109b4f7793d61b04b4478b1ad4d1465a719e7ff55b2d42461a/ty-0.0.38-py3-none-win32.whl", hash = "sha256:36fc5dd5dc09207ff3004b1560a79a3fb8d12456daeec914a7b802a918da654c", size = 10548583, upload-time = "2026-05-20T00:15:07.892Z" },
+    { url = "https://files.pythonhosted.org/packages/15/64/941b205e2e46cc2297c245c64aa7691410b7454fa4d07a6cb3cf59487833/ty-0.0.38-py3-none-win_amd64.whl", hash = "sha256:eef0a8956ba14514076b1a963d13eb32986d9ebad7f0527b3cc01cb68bf35147", size = 11650542, upload-time = "2026-05-20T00:15:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/59/02/c1c4f9ec4b94d95190636fa13f79c32f65165fbe3a0503882d4df164d2ac/ty-0.0.38-py3-none-win_arm64.whl", hash = "sha256:79abfc8658a026c30b1c955613437dab3ef4b12feca56a3e6df50903cc39e07f", size = 11010307, upload-time = "2026-05-20T00:15:04.567Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
Hey @cpojer, I mentioned this to you on twitter, but I've been thinking about / experimenting with what a python implementation of the server side of fate might look like. 

This PR isn't necessarily intended to be merged or merged as is (though I'd be open to working through it to land if you were interested). I think it could be entirely standalone.

I more just wanted to put up the PR to chat about the direction. AI was fairly heavily used in the development of this, but I've been actively editing and reviewing as well. Mostly just curious about your thoughts!

## A few notes on design

- I used Astral's ty for type checking
- I made it web framework agnostic, but added a few examples
- The SSE implementation is largely under-explored still, but I tried to provide an interface that could be implemented in different ways. 

## Open questions

- What work would I need to do to get codegen or the vite plugin working with this approach?